### PR TITLE
Workflow pipelines refactoring for structured data extraction completed

### DIFF
--- a/database/tables_backup/cpas.sql
+++ b/database/tables_backup/cpas.sql
@@ -72,11 +72,11 @@ END$$;
 CREATE EXTENSION IF NOT EXISTS citext;
 
 CREATE TABLE IF NOT EXISTS cpa_chemical_aliases (
+  id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   chemical_id  UUID   NOT NULL REFERENCES cpa_chemicals(id) ON DELETE CASCADE,
-  alias        CITEXT NOT NULL,
+  alias        CITEXT UNIQUE NOT NULL,
   embedding    vector(3072) NOT NULL,
   is_preferred BOOLEAN DEFAULT FALSE,
-  PRIMARY KEY (chemical_id, alias)      -- citext PK ⇒ case‑insensitive unique
 );
 CREATE UNIQUE INDEX IF NOT EXISTS uq_alias_global
     ON cpa_chemical_aliases (alias);

--- a/database/tables_backup/db_all_tables.sql
+++ b/database/tables_backup/db_all_tables.sql
@@ -1,0 +1,212 @@
+/* ════════════════════════════════════════════════════════════════
+   CryoDB – Minimal schema for Python‑side merge strategy
+   Version: 2025‑07‑29
+   Run with:  psql -f 00_base_schema.sql
+   ════════════════════════════════════════════════════════════════ */
+BEGIN;
+
+--------------------------------------------------------------------
+-- 1. Extensions  (idempotent)
+--------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";     -- uuid_generate_v4()
+CREATE EXTENSION IF NOT EXISTS citext;          -- case‑insensitive text
+CREATE EXTENSION IF NOT EXISTS vector;          -- pgvector (≥ 0.5.2)
+
+--------------------------------------------------------------------
+-- 2. Enumerated types
+--------------------------------------------------------------------
+-- 2.a Role of each cryoprotectant agent
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'cryoprotectant_roles') THEN
+    CREATE TYPE cryoprotectant_roles AS ENUM ('CPA', 'Adjuvant', 'Carrier');
+  END IF;
+END$$;
+
+-- 2.b Property type vocabulary  (used by agent‑properties)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'property_type') THEN
+    CREATE TYPE property_type AS ENUM (
+      'MOLECULAR_MASS', 'SOLUBILITY', 'VISCOSITY', 'TG_PRIME',
+      'PARTITION_COEFFICIENT', 'DIELECTRIC_CONSTANT', 'THERMAL_CONDUCTIVITY',
+      'HEAT_CAPACITY', 'THERMAL_EXPANSION_COEFFICIENT',
+      'CRYSTALLIZATION_TEMPERATURE', 'DIFFUSION_COEFFICIENT',
+      'HYDROGEN_BOND_DONORS_ACCEPTORS', 'SOURCE_OF_COMPOUND',
+      'GRAS_CERTIFICATION', 'MELTING_POINT', 'HYDROPHOBICITY', 'DENSITY',
+      'REFRACTIVE_INDEX', 'SURFACE_TENSION', 'PH', 'OSMOLALITY_OSMOLARITY',
+      'POLAR_SURFACE_AREA'
+    );
+  END IF;
+END$$;
+
+-- 2.c Kind of hybrid value stored in chemical_property_values
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'fact_value_kind') THEN
+    CREATE TYPE fact_value_kind AS ENUM ('POINT', 'RANGE', 'RAW', 'STRUCT');
+  END IF;
+END$$;
+
+--------------------------------------------------------------------
+-- 3. Core tables (agents + aliases)
+--------------------------------------------------------------------
+/* 3.a cpa_chemicals */
+CREATE TABLE IF NOT EXISTS cpa_chemicals (
+  id             UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+  inchikey       TEXT UNIQUE,
+  preferred_name TEXT        NOT NULL,
+  role           cryoprotectant_roles,
+  embedding      vector(3072),                 -- adjust dim if you use a smaller model
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (inchikey IS NULL OR inchikey ~* '^[A-Z]{14}-[A-Z]{10}-[A-Z]$')
+);
+
+/* auto‑update updated_at */
+CREATE OR REPLACE FUNCTION _touch_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql AS
+$$BEGIN NEW.updated_at = now(); RETURN NEW; END;$$;
+
+DROP TRIGGER IF EXISTS trg_touch_cpa_chemicals ON cpa_chemicals;
+CREATE TRIGGER trg_touch_cpa_chemicals
+BEFORE UPDATE ON cpa_chemicals
+FOR EACH ROW EXECUTE FUNCTION _touch_updated_at();
+
+/* 3.b cpa_chemical_aliases */
+CREATE TABLE IF NOT EXISTS cpa_chemical_aliases (
+  chemical_id  UUID   NOT NULL REFERENCES cpa_chemicals(id) ON DELETE CASCADE,
+  alias        CITEXT NOT NULL,
+  embedding    vector(3072) NOT NULL,
+  is_preferred BOOLEAN      DEFAULT FALSE,
+  PRIMARY KEY (chemical_id, alias)
+);
+
+/* unique globally to prevent “glucose” pointing to 2 chemicals */
+CREATE UNIQUE INDEX IF NOT EXISTS uq_alias_global
+    ON cpa_chemical_aliases (alias);
+
+/* ANN index for similarity search (vector cosine distance) */
+CREATE INDEX IF NOT EXISTS idx_alias_embedding_ann
+    ON cpa_chemical_aliases
+ USING ivfflat (embedding vector_cosine_ops)
+  WITH (lists = 100);
+
+--------------------------------------------------------------------
+-- 4. Agent‑property tables  (your insert_agent_properties helper)
+--------------------------------------------------------------------
+/* 4.a Property header */
+CREATE TABLE IF NOT EXISTS chemical_properties (
+  id           UUID          PRIMARY KEY DEFAULT uuid_generate_v4(),
+  chemical_id  UUID          NOT NULL REFERENCES cpa_chemicals(id) ON DELETE CASCADE,
+  prop_type    property_type NOT NULL,
+  UNIQUE (chemical_id, prop_type)
+);
+
+/* 4.b Hybrid value storage */
+CREATE TABLE IF NOT EXISTS chemical_property_values (
+  id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  property_id   UUID NOT NULL REFERENCES chemical_properties(id) ON DELETE CASCADE,
+
+  value_kind    fact_value_kind NOT NULL,
+
+  numeric_value NUMERIC,      -- for POINT
+  range_min     NUMERIC,      -- for RANGE
+  range_max     NUMERIC,      -- for RANGE
+  raw_value     TEXT,         -- for RAW
+  extra         JSONB,        -- for STRUCT
+
+  unit          TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (
+        (value_kind = 'POINT'  AND numeric_value IS NOT NULL
+                               AND range_min IS NULL AND range_max IS NULL
+                               AND raw_value IS NULL AND extra IS NULL)
+     OR (value_kind = 'RANGE'  AND range_min IS NOT NULL AND range_max IS NOT NULL
+                               AND numeric_value IS NULL
+                               AND raw_value IS NULL AND extra IS NULL)
+     OR (value_kind = 'RAW'    AND raw_value IS NOT NULL
+                               AND numeric_value IS NULL
+                               AND range_min IS NULL AND range_max IS NULL
+                               AND extra IS NULL)
+     OR (value_kind = 'STRUCT' AND extra IS NOT NULL
+                               AND numeric_value IS NULL
+                               AND range_min IS NULL AND range_max IS NULL
+                               AND raw_value IS NULL)
+  )
+);
+
+/* optional performance indexes */
+CREATE INDEX IF NOT EXISTS idx_propval_point
+    ON chemical_property_values (property_id, numeric_value)
+ WHERE value_kind = 'POINT';
+
+CREATE INDEX IF NOT EXISTS idx_propval_range
+    ON chemical_property_values
+ USING gist (property_id, numrange(range_min, range_max))
+ WHERE value_kind = 'RANGE';
+
+CREATE INDEX IF NOT EXISTS idx_propval_struct
+    ON chemical_property_values
+ USING gin (extra)
+ WHERE value_kind = 'STRUCT';
+
+/* 4.c Provenance (paper ↔ value) */
+CREATE TABLE IF NOT EXISTS cpa_references (
+  id                 UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  property_value_id  UUID NOT NULL REFERENCES chemical_property_values(id) ON DELETE CASCADE,
+  paper_id           TEXT NOT NULL,          -- DOI, arXiv, internal UUID …
+  quote              TEXT,
+  link               TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ref_propval
+    ON cpa_references (property_value_id);
+
+--------------------------------------------------------------------
+-- 5. Staging tables  (raw JSON from COPY)
+--------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS staging_cpa_chemicals (
+  data_json  JSONB            NOT NULL,
+  arrived_at TIMESTAMPTZ      DEFAULT now()
+);
+
+/* create more as you add pipeline steps */
+-- CREATE TABLE IF NOT EXISTS staging_cpa_properties (data_json jsonb, arrived_at timestamptz default now());
+
+--------------------------------------------------------------------
+-- 6. Misc helpers (optional)
+--------------------------------------------------------------------
+/* Table to log unvalidated or duplicate InChIKeys if you wish */
+CREATE TABLE IF NOT EXISTS cpa_unverified_inchikeys (
+  supplied_key TEXT PRIMARY KEY,
+  source_paper TEXT,
+  note         TEXT,
+  logged_at    TIMESTAMPTZ DEFAULT now()
+);
+
+COMMIT;
+
+-- add a per‑paper deterministic ID to experiments
+ALTER TABLE experiments
+    ADD COLUMN IF NOT EXISTS local_id TEXT;
+
+-- make (paper_id, local_id) unique so each ID is unambiguous inside one paper
+ALTER TABLE experiments
+    ADD CONSTRAINT IF NOT EXISTS uq_experiments_paper_local
+    UNIQUE (paper_id, local_id);
+
+/* ════════════════════════════════════════════════════════════════
+   Post‑installation notes
+   ----------------------------------------------------------------
+   • The ANN index (ivfflat) needs `SET enable_seqscan = off;`
+     or `SET ivfflat.probes` session parameter for best performance
+     during similarity search.
+   • If you use an embedding dimension other than 3 072, adjust the
+     `vector(3072)` declarations in *both* tables and rebuild the
+     ivfflat index.
+   • Nothing else (functions, triggers) is required because all
+     upsert / dedup logic lives in Python.
+   ════════════════════════════════════════════════════════════════ */

--- a/database/tables_backup/formulations_experiments.sql
+++ b/database/tables_backup/formulations_experiments.sql
@@ -1,0 +1,225 @@
+/* ════════════════════════════════════════════════════════════════
+   CryoDB – Experiment & Formulation stack (clean install)
+   public.{experiments, formulations, formulation_components,
+           formulation_properties, formulation_property_values,
+           formulation_references}
+   © CryoDB – rev. 2025‑07‑29
+   ════════════════════════════════════════════════════════════════
+   This script ONLY creates the objects that do **not** exist in the
+   “CPA core” schema you already defined (papers, cpa_chemicals, …).
+   Run inside an empty or partially‑populated cluster; everything is
+   idempotent and safe to re‑execute.
+   ────────────────────────────────────────────────────────────────*/
+
+/* ── 0. Extensions (create once per database) ─────────────────── */
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";       -- uuid_generate_v4()
+CREATE EXTENSION IF NOT EXISTS citext;            -- case‑insensitive text
+CREATE EXTENSION IF NOT EXISTS btree_gist;        -- GiST on NUMRANGE
+
+/* ── 1. Utility trigger to auto‑touch updated_at ──────────────── */
+DO $$
+BEGIN
+  IF NOT EXISTS (
+       SELECT 1 FROM pg_proc WHERE proname = '_touch_updated_at'
+     ) THEN
+CREATE OR REPLACE FUNCTION _touch_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $func$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$func$;
+  END IF;
+END$$;
+
+/* ── 2. ENUM types ────────────────────────────────────────────── */
+-- 2.a  Already‑existing enums (cryoprotectant_roles, fact_value_kind)
+--      are assumed present; create only if missing for clean install.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'cryoprotectant_roles') THEN
+    CREATE TYPE cryoprotectant_roles AS ENUM ('CPA', 'Adjuvant', 'Carrier');
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'fact_value_kind') THEN
+    CREATE TYPE fact_value_kind AS ENUM ('POINT', 'RANGE', 'RAW', 'STRUCT');
+  END IF;
+END$$;
+
+-- 2.b  Dependent property types (context‑aware measurements)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dependent_property_type') THEN
+    CREATE TYPE dependent_property_type AS ENUM (
+      'MEMBRANE_PERMEABILITY',
+      'TOXICITY',
+      'LOADING_TEMPERATURE',
+      'UNLOADING_TEMPERATURE',
+      'CRITICAL_COOLING_RATE',
+      'CRITICAL_WARMING_RATE'
+    );
+  END IF;
+END$$;
+
+/* ── 3. Table: experiments ───────────────────────────────────── */
+CREATE TABLE IF NOT EXISTS experiments (
+  id                      UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  paper_id                UUID NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+  local_id                TEXT,
+  performed_in_this_paper BOOLEAN      NOT NULL DEFAULT TRUE,
+  label                   TEXT,
+  method                  TEXT,
+  biological_context      JSONB,
+  quote                   TEXT          NOT NULL,
+  created_at              TIMESTAMPTZ   NOT NULL DEFAULT now(),
+  updated_at              TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_experiments_paper
+    ON experiments (paper_id);
+CREATE CONSTRAINT IF NOT EXISTS uq_experiments_paper_local
+    UNIQUE (paper_id, local_id);
+
+DROP TRIGGER IF EXISTS trg_touch_experiments ON experiments;
+CREATE TRIGGER trg_touch_experiments
+BEFORE UPDATE ON experiments
+FOR EACH ROW EXECUTE FUNCTION _touch_updated_at();
+
+/* ── 4. Table: formulations ──────────────────────────────────── */
+CREATE TABLE IF NOT EXISTS formulations (
+  id             UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  experiment_id  UUID    NOT NULL REFERENCES experiments(id) ON DELETE CASCADE,
+  label          CITEXT  NOT NULL,
+  quote          TEXT    NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (experiment_id, label)          -- avoid duplicate labels
+);
+CREATE INDEX IF NOT EXISTS idx_formulations_experiment
+    ON formulations (experiment_id);
+
+DROP TRIGGER IF EXISTS trg_touch_formulations ON formulations;
+CREATE TRIGGER trg_touch_formulations
+BEFORE UPDATE ON formulations
+FOR EACH ROW EXECUTE FUNCTION _touch_updated_at();
+
+/* ── 5. Table: formulation_components ────────────────────────── */
+CREATE TABLE IF NOT EXISTS formulation_components (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  formulation_id  UUID    NOT NULL REFERENCES formulations(id) ON DELETE CASCADE,
+  role            cryoprotectant_roles NOT NULL,
+  chemical_id     UUID REFERENCES cpa_chemicals(id) ON DELETE RESTRICT,
+  alias_id        UUID NOT NULL REFERENCES cpa_chemical_aliases(id) ON DELETE RESTRICT,
+  amount          NUMERIC,
+  unit            TEXT,
+  quote           TEXT   NOT NULL,
+  note            TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (
+        (role IN ('CPA','Adjuvant') AND chemical_id IS NOT NULL) OR
+        (role = 'Carrier'          AND chemical_id IS NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS idx_formcomp_formulation
+    ON formulation_components (formulation_id);
+CREATE INDEX IF NOT EXISTS idx_formcomp_role
+    ON formulation_components (role);
+CREATE INDEX IF NOT EXISTS idx_formcomp_chemical
+    ON formulation_components (chemical_id) WHERE chemical_id IS NOT NULL;
+
+DROP TRIGGER IF EXISTS trg_touch_formcomp ON formulation_components;
+CREATE TRIGGER trg_touch_formcomp
+BEFORE UPDATE ON formulation_components
+FOR EACH ROW EXECUTE FUNCTION _touch_updated_at();
+
+/* ── 6. Table: formulation_properties (header rows) ──────────── */
+CREATE TABLE IF NOT EXISTS formulation_properties (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  experiment_id   UUID NOT NULL REFERENCES experiments(id) ON DELETE CASCADE,
+
+  formulation_id  UUID REFERENCES formulations(id) ON DELETE CASCADE,
+  component_id    UUID REFERENCES formulation_components(id) ON DELETE CASCADE,
+
+  prop_type       dependent_property_type NOT NULL,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK ( (formulation_id IS NOT NULL AND component_id IS NULL) OR
+          (formulation_id IS NULL     AND component_id IS NOT NULL) ),
+
+  UNIQUE (experiment_id, prop_type, formulation_id, component_id)
+);
+CREATE INDEX IF NOT EXISTS idx_formprop_experiment
+    ON formulation_properties (experiment_id);
+CREATE INDEX IF NOT EXISTS idx_formprop_target
+    ON formulation_properties (formulation_id, component_id);
+
+DROP TRIGGER IF EXISTS trg_touch_formprops ON formulation_properties;
+CREATE TRIGGER trg_touch_formprops
+BEFORE UPDATE ON formulation_properties
+FOR EACH ROW EXECUTE FUNCTION _touch_updated_at();
+
+/* ── 7. Table: formulation_property_values ───────────────────── */
+CREATE TABLE IF NOT EXISTS formulation_property_values (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  property_id     UUID NOT NULL REFERENCES formulation_properties(id) ON DELETE CASCADE,
+
+  value_kind      fact_value_kind NOT NULL,
+
+  numeric_value   NUMERIC,
+  range_min       NUMERIC,
+  range_max       NUMERIC,
+  raw_value       TEXT,
+  extra           JSONB,
+
+  unit            TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (
+        (value_kind = 'POINT'  AND numeric_value IS NOT NULL
+                               AND range_min IS NULL AND range_max IS NULL
+                               AND raw_value IS NULL AND extra IS NULL)
+     OR (value_kind = 'RANGE'  AND range_min IS NOT NULL AND range_max IS NOT NULL
+                               AND numeric_value IS NULL
+                               AND raw_value IS NULL AND extra IS NULL)
+     OR (value_kind = 'RAW'    AND raw_value IS NOT NULL
+                               AND numeric_value IS NULL
+                               AND range_min IS NULL AND range_max IS NULL
+                               AND extra IS NULL)
+     OR (value_kind = 'STRUCT' AND extra IS NOT NULL
+                               AND numeric_value IS NULL
+                               AND range_min IS NULL AND range_max IS NULL
+                               AND raw_value IS NULL)
+  )
+);
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS idx_fpropval_point
+  ON formulation_property_values (property_id, numeric_value)
+  WHERE value_kind = 'POINT';
+
+CREATE INDEX IF NOT EXISTS idx_fpropval_range
+  ON formulation_property_values
+  USING gist (property_id, numrange(range_min, range_max))
+  WHERE value_kind = 'RANGE';
+
+CREATE INDEX IF NOT EXISTS idx_fpropval_struct
+  ON formulation_property_values USING gin (extra)
+  WHERE value_kind = 'STRUCT';
+
+/* ── 8. Table: formulation_references (provenance) ───────────── */
+CREATE TABLE IF NOT EXISTS formulation_references (
+  id                 UUID PRIMARY KEY DEFAULT uuid_generate_v4\(),
+  property_value_id  UUID NOT NULL
+                     REFERENCES formulation_property_values(id) ON DELETE CASCADE,
+  paper_id           TEXT NOT NULL,
+  quote              TEXT,
+  link               TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_fref_propval
+    ON formulation_references (property_value_id);
+
+/* ═══════════════════════  END  ════════════════════════════════ */

--- a/database/tables_backup/papers_table.sql
+++ b/database/tables_backup/papers_table.sql
@@ -30,7 +30,7 @@ CREATE TABLE papers (
   is_free_fulltext BOOLEAN,
   license          TEXT,
 
-  md5_hash         CHAR(64),
+  md5_hash         CHAR(32),
   file_size_bytes  INTEGER,
   file_s3_uri       TEXT,
   fulltext_s3_uri   TEXT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Aleksandr Sviridov"}
 ]
 readme = "README.md"
-requires-python = ">=3.13,<4.0"
+requires-python = ">=3.13,<3.14"
 dependencies = [
     "google-generativeai (>=0.8.5,<0.9.0)",
     "python-dotenv (>=1.1.1,<2.0.0)",
@@ -18,6 +18,9 @@ dependencies = [
     "openai (>=1.97.1,<2.0.0)",
     "llama-cloud-services (>=0.6.51,<0.7.0)",
     "pgvector (>=0.4.1,<0.5.0)",
+    "jinja2 (>=3.1.6,<4.0.0)",
+    "backoff (>=2.2.1,<3.0.0)",
+    "anthropic (>=0.60.0,<0.61.0)",
 ]
 
 

--- a/source/distiller/postgres_connection.py
+++ b/source/distiller/postgres_connection.py
@@ -6,6 +6,7 @@ import psycopg
 from psycopg import Connection as _PGConnection
 from psycopg import Cursor as _PGCursor
 from pgvector.psycopg import register_vector
+from psycopg.rows import dict_row
 
 
 _DB_NAME: str = os.getenv("PGDATABASE", "postgres")
@@ -44,7 +45,7 @@ def connection_ctx(**kwargs: Any) -> Generator[_PGConnection, None, None]:
 @contextmanager
 def cursor_ctx(commit: bool = False, **kwargs: Any) -> Generator[_PGCursor, None, None]:
     with connection_ctx(**kwargs) as conn:
-        cur = conn.cursor()
+        cur = conn.cursor(row_factory=dict_row)
         try:
             yield cur
             if commit:

--- a/source/distiller/schemas/extraction_passes.py
+++ b/source/distiller/schemas/extraction_passes.py
@@ -25,8 +25,8 @@ from pydantic import (
 )
 from distiller.schemas.structured_output import (
     ChemicalRole,           # enum (CPA / ADJUVANT / CARRIER)
-    FormulationComponent,   # validated component
-    Formulation             # validated formulation (incl. experiment_id, quote…)
+    Formulation,             # validated formulation (incl. experiment_id, quote…)
+    AgentProperty
 )
 
 
@@ -168,24 +168,5 @@ class AgentPropertyPass(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-class AgentProperty(BaseModel):
-    """
-    Intrinsic physicochemical property for a single agent (CPA / adjuvant).
-    These are formulation‑independent and map to the core CPA tables.
-    """
-    agent_id: Optional[str] = Field(None, description="InChIKey if available.")
-    agent_label: str
-    prop_type: PropertyType
-    value: FactValue
-    unit: Optional[str] = None
-    quote: str
 
-    model_config = ConfigDict(extra="forbid")
-
-    # ── validation (InChIKey) ────────────────────────────────────
-    @field_validator("agent_id")
-    @classmethod
-    def _validate_agent_id(cls, v: Optional[str]) -> Optional[str]:
-        if v and not _INCHIKEY_RE.match(v):
-            raise ValueError("agent_id is not a valid InChIKey.")
-        return v
+        

--- a/source/distiller/schemas/extraction_passes.py
+++ b/source/distiller/schemas/extraction_passes.py
@@ -1,0 +1,191 @@
+"""
+CryoDB – Extraction‑pass schemas  (Markdown‑aware pipeline)
+────────────────────────────────────────────────────────────
+These pydantic models are used *only at pipeline runtime* to validate
+and normalise the JSON returned by the LLM.
+
+• MoleculeCoreData      – Pass 1  (chemicals / “agents”, formulation‑independent)
+• ExperimentPass   – Pass 2  (experiments + biological context)
+• FormulationPass  – Pass 3  (formulations + dependent properties)
+• AgentProperty    – Intrinsic physicochemical properties (new)
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union, Literal
+from uuid import UUID, uuid4
+
+from pydantic import (
+    BaseModel,
+    Field,
+    ConfigDict,
+    field_validator,
+)
+from distiller.schemas.structured_output import (
+    ChemicalRole,           # enum (CPA / ADJUVANT / CARRIER)
+    FormulationComponent,   # validated component
+    Formulation             # validated formulation (incl. experiment_id, quote…)
+)
+
+
+# ────────────────────────────────────────────────────────────────
+# 0.  Shared helpers / vocab
+# ────────────────────────────────────────────────────────────────
+_INCHIKEY_RE = re.compile(r"^[A-Z0-9]{14}-[A-Z0-9]{10}-[A-Z]$")
+
+class ChemicalRole(str, Enum):
+    CPA      = "CPA"
+    ADJUVANT = "ADJUVANT"
+    CARRIER  = "CARRIER"
+# ── value helpers (point / range / raw / struct) ─────────────────
+class NumericValue(BaseModel):
+    value_type: Literal["point"]
+    value: float | int
+    model_config = ConfigDict(extra="forbid")
+
+class NumericRange(BaseModel):
+    value_type: Literal["range"]
+    min: float | int
+    max: float | int
+    model_config = ConfigDict(extra="forbid")
+
+RawScalar = Union[str, float, int]        # e.g. "hydrophilic", 7.4
+StructuredValue = Dict[str, Any]          # arbitrary JSON for complex structs
+
+FactValue = Union[NumericValue, NumericRange, RawScalar, StructuredValue]
+
+# schemas/extraction_passes.py  (add at the bottom)
+
+class AgentsPass(BaseModel):
+    agents: List[MoleculeCoreData]
+    model_config = ConfigDict(extra="forbid")
+
+# ────────────────────────────────────────────────────────────────
+# 1.  Pass 1 – MoleculeCoreData (chemicals, formulation‑independent)
+# ────────────────────────────────────────────────────────────────
+class MoleculeCoreData(BaseModel):
+    """One *chemical agent* extracted from the paper."""
+    inchikey: Optional[str] = Field(None, description="Use standard InChIKey when possible.")
+    preferred_name: str
+    synonyms: List[str] = Field(default_factory=list)
+    role: ChemicalRole
+
+    model_config = ConfigDict(extra="forbid")
+
+    # ── validation ──────────────────────────────────────────────
+    @field_validator("inchikey")
+    @classmethod
+    def _validate_inchikey(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not _INCHIKEY_RE.match(v):
+            raise ValueError("Invalid InChIKey format.")
+        return v
+
+
+# ────────────────────────────────────────────────────────────────
+# 2.  Pass 2 – ExperimentPass
+# ────────────────────────────────────────────────────────────────
+class SampleContext(BaseModel):
+    organ: Optional[str] = None
+    tissue: Optional[str] = None
+    species: Optional[str] = None
+    cell_line: Optional[str] = None
+    dimensions: Optional[str] = None
+    health_status: Optional[str] = None
+    developmental_stage: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+class ExperimentItem(BaseModel):
+    """A single experiment identified in a heading‑based chunk."""
+    id: str = Field(..., description="Deterministic ID (e.g. 'EXPT‑003').")
+    performed_in_this_paper: bool = True
+    label: Optional[str] = None
+    method: Optional[str] = None
+    biological_context: Optional[SampleContext] = None
+    quote: str
+    source_chunk        : List[str] = Field(default_factory=list, description="The source chunk of the experiment. It must be exact extracted from the paper, and fragmented if needed to include all numeric values. Minimum length is 1000 words")
+    model_config = ConfigDict(extra="forbid")
+
+class ExperimentPass(BaseModel):
+    """Top‑level container returned by the experiment extractor."""
+
+    experiments: List[ExperimentItem]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ────────────────────────────────────────────────────────────────
+# 3.  Pass 3 – FormulationPass
+# ────────────────────────────────────────────────────────────────
+# Top‑level container returned by the LLM
+class FormulationPass(BaseModel):
+    """
+    Wrapper returned by the formulation‑extraction prompt.
+    Re‑uses the `Formulation` model defined in distiller.schemas.structured_output.
+    """
+    formulations: List[Formulation]
+
+    # forbid arbitrary extra keys, just like your other passes
+    model_config = ConfigDict(extra="forbid")
+# ────────────────────────────────────────────────────────────────
+# 4.  Intrinsic physicochemical properties – AgentProperty
+# ────────────────────────────────────────────────────────────────
+class PropertyType(str, Enum):
+    MOLECULAR_MASS                 = "MOLECULAR_MASS"
+    SOLUBILITY                     = "SOLUBILITY"
+    VISCOSITY                      = "VISCOSITY"
+    TG_PRIME                       = "TG_PRIME"
+    PARTITION_COEFFICIENT          = "PARTITION_COEFFICIENT"
+    DIELECTRIC_CONSTANT            = "DIELECTRIC_CONSTANT"
+    THERMAL_CONDUCTIVITY           = "THERMAL_CONDUCTIVITY"
+    HEAT_CAPACITY                  = "HEAT_CAPACITY"
+    THERMAL_EXPANSION_COEFFICIENT  = "THERMAL_EXPANSION_COEFFICIENT"
+    CRYSTALLIZATION_TEMPERATURE    = "CRYSTALLIZATION_TEMPERATURE"
+    DIFFUSION_COEFFICIENT          = "DIFFUSION_COEFFICIENT"
+    HYDROGEN_BOND_DONORS_ACCEPTORS = "HYDROGEN_BOND_DONORS_ACCEPTORS"
+    SOURCE_OF_COMPOUND             = "SOURCE_OF_COMPOUND"
+    GRAS_CERTIFICATION             = "GRAS_CERTIFICATION"
+    MELTING_POINT                  = "MELTING_POINT"
+    HYDROPHOBICITY                 = "HYDROPHOBICITY"
+    DENSITY                        = "DENSITY"
+    REFRACTIVE_INDEX               = "REFRACTIVE_INDEX"
+    SURFACE_TENSION                = "SURFACE_TENSION"
+    PH                             = "PH"
+    OSMOLALITY_OSMOLARITY          = "OSMOLALITY_OSMOLARITY"
+    POLAR_SURFACE_AREA             = "POLAR_SURFACE_AREA"
+# ────────────────────────────────────────────────────────────────
+# 4‑bis · Pass 1‑B – intrinsic agent properties
+# ────────────────────────────────────────────────────────────────
+class AgentPropertyPass(BaseModel):
+    """
+    One JSON envelope per paper – list of intrinsic properties
+    for the chemicals that appeared in `MoleculeCoreData`.
+    """
+
+    properties: List[AgentProperty]
+
+    model_config = ConfigDict(extra="forbid")
+
+class AgentProperty(BaseModel):
+    """
+    Intrinsic physicochemical property for a single agent (CPA / adjuvant).
+    These are formulation‑independent and map to the core CPA tables.
+    """
+    agent_id: Optional[str] = Field(None, description="InChIKey if available.")
+    agent_label: str
+    prop_type: PropertyType
+    value: FactValue
+    unit: Optional[str] = None
+    quote: str
+
+    model_config = ConfigDict(extra="forbid")
+
+    # ── validation (InChIKey) ────────────────────────────────────
+    @field_validator("agent_id")
+    @classmethod
+    def _validate_agent_id(cls, v: Optional[str]) -> Optional[str]:
+        if v and not _INCHIKEY_RE.match(v):
+            raise ValueError("agent_id is not a valid InChIKey.")
+        return v

--- a/source/distiller/schemas/papers.py
+++ b/source/distiller/schemas/papers.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import UUID
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class PaperStatus(str, Enum):
@@ -59,3 +59,10 @@ class Paper(BaseModel):
     class Config:  # type: ignore[override]
         orm_mode = True  # Pydantic v1; accepted by v2 as well
         from_attributes = True  # Pydantic v2 equivalent
+
+    # ───────────────────────── validators ────────────────────────
+    @field_validator("md5_hash", mode="before")
+    @classmethod
+    def _strip_md5(cls, v: str | None) -> str | None:
+        """Trim stray spaces/newlines around the MD5 string."""
+        return v.strip() if isinstance(v, str) else v

--- a/source/distiller/schemas/structured_output.py
+++ b/source/distiller/schemas/structured_output.py
@@ -128,6 +128,20 @@ FACT_UNIT_DEFAULTS = FactUnitDefaults(
     POLAR_SURFACE_AREA            = UnitSpec(defaultUnit="A2",          units=["A2"]),
 )
 
+class DependentPropertyType(str, Enum):
+    MEMBRANE_PERMEABILITY   = "MEMBRANE_PERMEABILITY"
+    TOXICITY                = "TOXICITY"
+    LOADING_TEMPERATURE     = "LOADING_TEMPERATURE"
+    UNLOADING_TEMPERATURE   = "UNLOADING_TEMPERATURE"
+    CRITICAL_COOLING_RATE   = "CRITICAL_COOLING_RATE"
+    CRITICAL_WARMING_RATE   = "CRITICAL_WARMING_RATE"
+class DependentProperty(BaseModel):
+    property_id     : UUID = Field(default_factory=uuid4)
+    property_type   : DependentPropertyType
+    value           : FactValue          # POINT / RANGE / STRUCT / RAW
+    unit            : Optional[str] = None
+    quote           : str
+    model_config    = ConfigDict(extra="forbid")
 # ────────────────────────────────────────────────────────────────
 # Base class for dimension types
 class DimensionBase(BaseModel):
@@ -205,8 +219,9 @@ class FormulationComponent(BaseModel):
     agent_id     : Optional[str] = Field(
         None, description="InChIKey of the chemical component."
     )
-    amount       : Optional[NumericValue] = None
+    amount       : NumericValue
     unit         : Optional[str] = None
+    
     quote        : str
     note         : Optional[str] = None
     model_config = ConfigDict(extra="forbid")
@@ -217,8 +232,9 @@ class Formulation(BaseModel):
     formulation_id : UUID = Field(default_factory=uuid4)
     label          : str
     components     : List[FormulationComponent]
-    experiment_id  : UUID
-    quote          : str
+    experiment_id: str   # links back to ExperimentItem.id
+    dependent_properties : List[DependentProperty] = Field(default_factory=list)
+    quote          : str = Field(description="The source chunk of the formulation. It must be exact extracted from the paper, and fragmented if needed to include all numeric values. Minimum length is 200 words. If needed, use ... to separate different chunks of text. ALWAYS EXACT QUOTE EXTRACTED FROM TEXT") # must be exact extracted from the paper, and fragmented if needed to include all numeric values
     model_config   = ConfigDict(extra="forbid")
 
 # ────────────────────────────────────────────────────────────────
@@ -230,6 +246,7 @@ class Experiment(BaseModel):
     method              : Optional[str] = None
     biological_context  : Optional[SampleContext] = None
     quote               : str
+    source_chunk        : List[str] = Field(default_factory=list, description="The source chunk of the experiment. It must be exact extracted from the paper, and fragmented if needed to include all numeric values. Minimum length is 1000 words")
     model_config = ConfigDict(extra="forbid")
 
 # ────────────────────────────────────────────────────────────────

--- a/source/distiller/utils/llm_extraction.py
+++ b/source/distiller/utils/llm_extraction.py
@@ -1,0 +1,97 @@
+import json, backoff, time
+from typing import Dict, Any, List
+from openai import OpenAI
+from pydantic import BaseModel, ValidationError
+from distiller.utils.file_utils import clean_json_response
+from distiller.schemas.extraction_passes import AgentPropertyPass, AgentsPass, ExperimentPass, FormulationPass
+from jinja2 import Environment, FileSystemLoader
+_jinja = Environment(loader=FileSystemLoader("source/prompts"))
+import os
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+def _llm_extract(
+    prompt: str,
+    schema_model: type[BaseModel],
+    model: str =    "gpt-4o-mini",
+    max_retries: int = 3,
+) -> dict | None:
+    """Generic: send prompt, coerce to schema, retry with validator feedback."""
+    messages: List[Dict[str, str]] = [{"role": "user", "content": prompt}]
+
+    @backoff.on_exception(backoff.expo, Exception, max_tries=max_retries)
+    def _call(messages):
+        return client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0,
+            response_format={"type": "json_object"},
+        )
+
+    for attempt in range(1, max_retries + 1):
+        raw = _call(messages).choices[0].message.content
+        text = raw if isinstance(raw, str) else json.dumps(raw)
+        text = clean_json_response(text) if "clean_json_response" in globals() else text
+
+        try:
+            data = json.loads(text)
+            parsed = schema_model.model_validate(data)     # <- strict validation
+            return json.loads(parsed.model_dump_json(by_alias=True))
+        except (json.JSONDecodeError, ValidationError) as err:
+            if attempt == max_retries:
+                print(f"[ERROR] LLM output invalid after {max_retries} tries: {err}")
+                return None
+            # feed validator errors back to the model
+            messages += [
+                {"role": "assistant", "content": raw},
+                {
+                    "role": "user",
+                    "content": (
+                        "The JSON did not pass validation:\n"
+                        f"{err}\n"
+                        "Please correct it and return ONLY the JSON object."
+                    ),
+                },
+            ]
+def extract_agents(paper_text: str) -> list[dict] | None:
+    prompt = _jinja.get_template("agent_prompt.j2").render(
+        PAPER_TEXT=paper_text, SCHEMA=AgentsPass.model_json_schema()
+    )
+    return _llm_extract(prompt, AgentsPass)
+
+def extract_experiments(paper_text: str) -> list[dict] | None:
+    """Run a single ExperimentPass over the full paper."""
+    prompt = _jinja.get_template("experiment_extraction/v4_experiment_prompt.j2").render(
+        PAPER_TEXT=paper_text,
+        SCHEMA=ExperimentPass.model_json_schema(),
+    )
+    parsed = _llm_extract(prompt, ExperimentPass)
+    return parsed["experiments"] if parsed else None
+
+def extract_agent_properties(paper_text: str) -> list[dict] | None:
+    prompt = _jinja.get_template("agent_property_prompt.j2").render(
+        PAPER_TEXT=paper_text,
+        SCHEMA=AgentPropertyPass.model_json_schema(),
+    )
+    parsed = _llm_extract(prompt, AgentPropertyPass)
+    return parsed["properties"] if parsed else None
+
+def extract_formulations(paper_text: str, experiments: list[dict]) -> list[dict]:
+    all_forms: list[dict] = []
+
+    for exp in experiments:
+        prompt = _jinja.get_template("formulation_extraction/v5_formulation_prompt.j2").render(
+            PAPER_TEXT = paper_text,            # single prompt per exp
+            EXPERIMENT_ID = exp["id"],
+            SCHEMA = FormulationPass.model_json_schema(),
+        )
+        parsed = _llm_extract(prompt, FormulationPass)
+        if not parsed:
+            continue
+
+        for form in parsed["formulations"]:
+            form["experiment_id"] = exp["id"]      #  ← restore link
+
+        all_forms.extend(parsed["formulations"])
+
+    return all_forms

--- a/source/extractor.py
+++ b/source/extractor.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     if os.path.isdir(input_path):
         pdf_files = list(Path(input_path).glob("*.pdf"))
         if pdf_files:
-            run_pipeline(pdf_files, source_files="local_directory", config=PipelineConfig(distiller="llama_parse", llm_model_parser="gpt-4.1-mini"))
+            run_pipeline(pdf_files, source_files="local_directory", config=PipelineConfig(distiller="llama_parse", llm_model_parser="claude-sonnet-4-20250514"))
             exit(0)
         else:
             print(f"No PDF files found in directory '{input_path}'.")

--- a/source/extractor.py
+++ b/source/extractor.py
@@ -11,6 +11,8 @@ from distiller.pmc.get_papers import get_papers_from_pmc
 from distiller.pmc.get_cpa_facts import get_cpa_facts_from_papers
 from pipelines.pipeline_orchestration import run_pipeline       
 from distiller.schemas.pipeline_config import PipelineConfig
+import nest_asyncio, asyncio, logging
+nest_asyncio.apply()                  # allows re‑entrancy
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 
 if not GEMINI_API_KEY:

--- a/source/pipelines/ingest/merge_agents.py
+++ b/source/pipelines/ingest/merge_agents.py
@@ -1,0 +1,118 @@
+"""
+Python‑only merge from MoleculeCoreData JSON → live tables.
+
+Depends on:
+    • distiller.postgres_connection.cursor_ctx
+    • pipelines.utils.embeddings.get_embedding
+"""
+from __future__ import annotations
+from typing import Iterable
+import re
+from distiller.postgres_connection import cursor_ctx
+from distiller.schemas.extraction_passes import MoleculeCoreData
+from pipelines.utils.embeddings import get_embedding
+
+SIMILARITY_THRESHOLD = 0.38
+_INCHI_RE = re.compile(r"^[A-Z]{14}-[A-Z]{10}-[A-Z]$")
+
+# ── SQL snippets ─────────────────────────────────────────────────
+_SQL_NEAREST_ALIAS = """
+SELECT chemical_id,
+       embedding <-> (%(qvec)s)::vector AS dist
+  FROM cpa_chemical_aliases
+ ORDER BY embedding <-> (%(qvec)s)::vector
+ LIMIT 1;
+"""
+
+
+_SQL_INSERT_CHEM = """
+INSERT INTO cpa_chemicals (inchikey, preferred_name, role, embedding)
+VALUES (%(inchikey)s, %(pref)s, %(role)s, %(emb)s)
+ON CONFLICT (inchikey) DO UPDATE
+   SET preferred_name = EXCLUDED.preferred_name,
+       role           = EXCLUDED.role,
+       embedding      = EXCLUDED.embedding
+RETURNING id;
+"""
+
+_SQL_INSERT_CHEM_TEXT = """
+INSERT INTO cpa_chemicals (preferred_name, role, embedding)
+VALUES (%(pref)s, %(role)s, %(emb)s)
+ON CONFLICT (preferred_name) DO UPDATE
+   SET role      = EXCLUDED.role,
+       embedding = EXCLUDED.embedding
+RETURNING id;
+"""
+
+_SQL_INSERT_ALIAS = """
+INSERT INTO cpa_chemical_aliases
+    (chemical_id, alias, embedding, is_preferred)
+VALUES (%s, %s, %s, %s)
+ON CONFLICT DO NOTHING;
+"""
+
+# ── main entry point ────────────────────────────────────────────
+def merge_agents(rows: Iterable[dict]) -> int:
+    """
+    Upsert a batch of MoleculeCoreData rows.
+
+    Returns
+    -------
+    int
+        Number of agent JSON objects processed (for logging/metrics).
+    """
+    processed = 0
+
+    with cursor_ctx(commit=True) as cur:
+        for raw in rows:
+            print("RAW: ", raw)
+            agent = MoleculeCoreData.model_validate(raw)
+
+            # 1. Find closest alias
+            qvec = get_embedding(agent.preferred_name.lower().strip())
+            cur.execute(_SQL_NEAREST_ALIAS, {"qvec": qvec})
+            hit = cur.fetchone()
+
+            # 2. Choose insert strategy
+            if hit and hit["dist"] < SIMILARITY_THRESHOLD:
+                chem_id = hit["chemical_id"]
+            else:
+                if agent.inchikey and _INCHI_RE.match(agent.inchikey):
+                    cur.execute(
+                        _SQL_INSERT_CHEM,
+                        dict(
+                            inchikey=agent.inchikey,
+                            pref=agent.preferred_name,
+                            role=agent.role.value,
+                            emb=qvec,
+                        ),
+                    )
+                else:
+                    cur.execute(
+                        _SQL_INSERT_CHEM_TEXT,
+                        dict(
+                            pref=agent.preferred_name,
+                            role=agent.role.value,
+                            emb=qvec,
+                        ),
+                    )
+                chem_id = cur.fetchone()["id"]
+
+            # 3. Insert aliases in bulk with executemany
+            alias_rows = [
+                (
+                    chem_id,
+                    name,
+                    get_embedding(name.lower().strip()),
+                    is_pref,
+                )
+                for name, is_pref in (
+                    [(agent.preferred_name, True)]
+                    + [(s, False) for s in agent.synonyms]
+                )
+            ]
+            cur.executemany(_SQL_INSERT_ALIAS, alias_rows)
+
+            processed += 1
+
+    return processed

--- a/source/pipelines/ingest/staging.py
+++ b/source/pipelines/ingest/staging.py
@@ -1,0 +1,35 @@
+"""
+COPY raw JSON rows into a staging table.
+
+Relies on:
+    • distiller.postgres_connection.cursor_ctx
+    • psycopg 3.1+
+"""
+from __future__ import annotations
+import io, json
+from psycopg import sql
+from distiller.postgres_connection import cursor_ctx
+
+
+def copy_json(rows: list[dict], staging_table: str) -> None:
+    """
+    Bulk‑insert a list of JSON‑serialisable dicts into `<staging_table>`,
+    using `COPY … FROM STDIN` for maximum throughput.
+    """
+    if rows == []:
+        raise Exception("No rows to copy")
+    if not rows:
+        return
+
+    # Minified newline‑separated JSON for COPY
+    payload = "\n".join(json.dumps(r, separators=(",", ":")) for r in rows)
+
+    with cursor_ctx(commit=True) as cur:
+        # Safely quote the table name
+        stmt = sql.SQL("COPY {} (data_json) FROM STDIN").format(
+            sql.Identifier(staging_table)
+        )
+
+        # Context‑manager copy object
+        with cur.copy(stmt) as copy:
+            copy.write(payload) 

--- a/source/pipelines/pipeline_orchestration.py
+++ b/source/pipelines/pipeline_orchestration.py
@@ -1,19 +1,83 @@
 from pipelines.extract.llama_parse import extract_fulltext as extract_fulltext_llama_parse
-from pipelines.utils.paper_utils import update_metadata_from_fulltext, get_cpa_facts_from_fulltext
-from pipelines.post_processing.cpa_ingest import store_cpa_data
+from pipelines.utils.paper_utils import update_metadata_from_fulltext
+from pipelines.utils.pipeline_utils import update_workflow_status
+from pipelines.post_processing.agent_property_ingest import insert_agent_properties
+from pipelines.post_processing.experiment_ingest import insert_experiments
+from pipelines.post_processing.formulation_ingest import insert_formulations   # NEW
 from distiller.schemas.pipeline_config import PipelineConfig
+from distiller.utils.llm_extraction import (
+    extract_agents,
+    extract_agent_properties,
+    extract_experiments,
+    extract_formulations,                                            # NEW
+)
+from pipelines.ingest.staging import copy_json
+from pipelines.ingest.merge_agents import merge_agents
+# ── timing helper  (put near the top of your file) ──────────────────
+from contextlib import contextmanager
+import time, logging
+from distiller.schemas.papers import PaperStatus
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%H:%M:%S",
+)
+@contextmanager
+def timed(label: str):
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        dt = time.perf_counter() - t0
+        logging.info(f"[TIMER] {label:<35} {dt:6.2f} s")
 
 
 def run_pipeline(files: list[str], source_files: str, config: PipelineConfig):
+
     if config.distiller == "llama_parse" and config.llm_model_parser == "gpt-4.1-mini":
         for md5_hash, fulltext in extract_fulltext_llama_parse(files, source_files):
-            update_metadata_from_fulltext(md5_hash, fulltext)
-            status = get_cpa_facts_from_fulltext(md5_hash)
+            with timed("0‑update_metadata"):
+                paper_id = update_metadata_from_fulltext(md5_hash, fulltext)
+                if paper_id is None:
+                    print(f"[ERROR] Failed to update metadata for {md5_hash}")
+                    update_workflow_status(md5_hash, PaperStatus.FAILED)
+                    continue
 
-            # Post-processing
-            if status == "FAILED":
-                continue
-            store_cpa_data(md5_hash)
+        # ── Agents ───────────────────────────────────────────────
+            with timed("1‑extract_agents"):
+                agents = extract_agents(fulltext)
+                if agents is None:
+                    print(f"[ERROR] Failed to extract agents for {md5_hash}")
+                    update_workflow_status(md5_hash, PaperStatus.FAILED)
+                    continue
+            with timed("1a‑merge_agents"):
+                agent_rows = agents.get("agents", [])
+                if agent_rows:
+                    copy_json(agent_rows, "staging_cpa_chemicals")
+                    merge_agents(agent_rows)
 
-    else:
-        raise ValueError(f"Unknown distiller: {config.distiller}")
+        # ── Agent‑level props ───────────────────────────────────
+            with timed("2‑extract_agent_props"):
+                props = extract_agent_properties(fulltext)
+            with timed("2a‑insert_agent_props"):
+                if props:
+                    insert_agent_properties(paper_id, props)
+
+        # ── Experiments ─────────────────────────────────────────
+            with timed("3‑extract_experiments"):
+                experiments = extract_experiments(fulltext)
+            with timed("3a‑insert_experiments"):
+                if experiments is not None:
+                    print(f'[TRACE] experiments: {experiments}')
+                    insert_experiments(md5_hash, experiments)
+                    with timed("4‑extract_formulations"):
+                        formulations = extract_formulations(fulltext,experiments)
+                    with timed("4a‑insert_formulations"):
+                        if formulations:
+                            print(f'[TRACE] formulations: {formulations}')
+                            insert_formulations(md5_hash, formulations, experiments)
+                else:
+                    print(f"[ERROR] Failed to extract experiments for {md5_hash}")
+                    update_workflow_status(md5_hash, PaperStatus.FAILED)
+

--- a/source/pipelines/post_processing/agent_property_ingest.py
+++ b/source/pipelines/post_processing/agent_property_ingest.py
@@ -1,0 +1,154 @@
+"""
+Insert AgentProperty objects directly into the CPA core tables.
+
+Resolution strategy
+───────────────────
+1. Exact match on InChIKey (fast path).
+2. Semantic match on any alias embedding within `SIMILARITY_THRESHOLD`.
+   • Uses pgvector `<->` distance against cpa_chemical_aliases.embedding.
+3. If no match → skip property and log a warning.  (The agents pass
+   should have inserted the chemical already, so this is rare.)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Dict, Any, Tuple
+from uuid import UUID
+
+from distiller.postgres_connection import cursor_ctx
+from pipelines.utils.embeddings import get_embedding  # same helper you use elsewhere
+from pipelines.utils.embeddings import SIMILARITY_THRESHOLD
+
+# ----------------------------------------------------------------------
+# helpers identical to ingest-CPA code (kept local to avoid circular deps)
+# ----------------------------------------------------------------------
+_INCHI_PAT = re.compile(r"^[A-Z]{14}-[A-Z]{10}-[A-Z]$", re.I)
+
+def _is_valid_inchikey(k: str | None) -> bool:
+    return bool(k and _INCHI_PAT.match(k))
+
+def _canon(text: str) -> str:
+    return text.strip().lower()
+
+
+# ----------------------------------------------------------------------
+# value-mapping helper
+# ----------------------------------------------------------------------
+def _value_kind_and_columns(val: Any) -> Tuple[str, Dict[str, Any]]:
+    if isinstance(val, (int, float)):
+        return "POINT", {"numeric_value": val}
+    if isinstance(val, str):
+        return "RAW", {"raw_value": val}
+
+    vtype = val.get("value_type")
+    if vtype == "point":
+        return "POINT", {"numeric_value": val["value"]}
+    if vtype == "range":
+        return "RANGE", {"range_min": val["min"], "range_max": val["max"]}
+
+    return "STRUCT", {"extra": json.dumps(val)}
+
+
+# ----------------------------------------------------------------------
+# chemical resolution (InChIKey ► exact  ·  name ► embedding)
+# ----------------------------------------------------------------------
+_EMBED_SQL = """
+SELECT chemical_id, alias, embedding <-> %s::vector AS dist
+FROM   cpa_chemical_aliases
+ORDER  BY dist
+LIMIT  1;
+"""
+
+def _resolve_chemical_id(cur, inchikey: str | None, label: str) -> UUID | None:
+    # 1. exact InChIKey
+    if _is_valid_inchikey(inchikey):
+        cur.execute("SELECT id FROM cpa_chemicals WHERE inchikey = %s;", (inchikey,))
+        row = cur.fetchone()
+        if row:
+            return row["id"]
+
+    # 2. semantic alias match
+    vec = get_embedding(_canon(label))
+    cur.execute(_EMBED_SQL, (vec,))
+    row = cur.fetchone()
+    if row and row["dist"] < SIMILARITY_THRESHOLD:
+        return row["chemical_id"]
+
+    return None
+
+
+# ----------------------------------------------------------------------
+# main API
+# ----------------------------------------------------------------------
+def insert_agent_properties(
+    paper_id: str,
+    props: List[Dict[str, Any]],
+) -> None:
+    """
+    Insert each AgentProperty into
+      chemical_properties → chemical_property_values → cpa_references
+    If the chemical cannot be resolved, the property is skipped.
+    """
+    if not props:
+        return
+
+    skipped = 0
+    with cursor_ctx(commit=True) as cur:
+        print(f'[TRACE] insert_agent_properties:')
+        for p in props:
+            print(f'\t{p}')
+            chem_id = _resolve_chemical_id(cur, p.get("agent_id"), p["agent_label"])
+            if chem_id is None:
+                skipped += 1
+                continue   # cannot attach property
+
+            # 1. ensure header row exists
+            cur.execute(
+                """
+                INSERT INTO chemical_properties (chemical_id, prop_type)
+                VALUES (%s, %s::property_type)
+                ON CONFLICT (chemical_id, prop_type) DO NOTHING
+                RETURNING id;
+                """,
+                (chem_id, p["prop_type"]),
+            )
+            row = cur.fetchone()
+            if row:
+                prop_id = row["id"]
+            else:
+                cur.execute(
+                    "SELECT id FROM chemical_properties "
+                    "WHERE chemical_id = %s AND prop_type = %s::property_type",
+                    (chem_id, p["prop_type"]),
+                )
+                prop_id = cur.fetchone()["id"]
+
+            # 2. value row
+            kind, colmap = _value_kind_and_columns(p["value"])
+            columns = ["property_id", "value_kind", *colmap.keys(), "unit"]
+            values  = [prop_id, kind, *colmap.values(), p.get("unit")]
+
+            cols_sql = ", ".join(columns)
+            ph_sql   = ", ".join(["%s"] * len(values))
+
+            cur.execute(
+                f"INSERT INTO chemical_property_values ({cols_sql}) "
+                f"VALUES ({ph_sql}) RETURNING id;",
+                tuple(values),
+            )
+            val_id = cur.fetchone()["id"]
+
+            # 3. provenance
+            cur.execute(
+                """
+                INSERT INTO cpa_references (property_value_id, paper_id, quote)
+                VALUES (%s, %s, %s);
+                """,
+                (val_id, paper_id, p["quote"]),
+            )
+
+    if skipped:
+        print(f"[WARN] insert_agent_properties: {skipped} properties skipped "
+              f"(chemical not found via InChIKey or embedding)")

--- a/source/pipelines/post_processing/cpa_ingest.py
+++ b/source/pipelines/post_processing/cpa_ingest.py
@@ -3,7 +3,7 @@ Utility that ingests the JSON produced by the LLM pipeline
 into the 4‑table normalised store.
 """
 from __future__ import annotations
-
+import re
 import json, hashlib
 from typing import Dict, Any
 from datetime import datetime
@@ -16,88 +16,123 @@ from distiller.schemas.cpa_chemical import (
 from distiller.schemas.structured_output import CPAPaperData
 from distiller.postgres_connection import connection_ctx
 from pipelines.utils.embeddings import get_embedding
-SIMILARITY_THRESHOLD = 0.20            # cosine distance (0 = identical)
+SIMILARITY_THRESHOLD = 0.38
+_INCHI_PAT = re.compile(r"^[A-Z]{14}-[A-Z]{10}-[A-Z]$", re.I)
 
-def _merge_synonyms(cur, chem_id: str, new_syns: List[str]) -> None:
+def _is_valid_inchikey(k: str | None) -> bool:
+    return bool(k and _INCHI_PAT.match(k))
+
+def _canon(text: str) -> str:
+    """Return the canonical form used for dedup + embedding."""
+    return text.strip().lower()
+
+def _upsert_aliases(cur, chem_id: str, preferred: str, syns: list[str]) -> None:
     """
-    Merge new synonyms into existing JSONB array; keeps them unique.
+    • Insert the preferred name (is_preferred = True)
+    • Insert each synonym once (is_preferred = False)
+    • Skip duplicates within the same call
+    • Use the canonical text to compute the embedding
     """
-    if not new_syns:
-        return
-    cur.execute(
-        """
-        UPDATE cpa_chemicals
-        SET synonyms = (
-              SELECT jsonb_agg(DISTINCT x)
-              FROM   jsonb_array_elements_text(synonyms || %s::jsonb) AS t(x)
-        )
-        WHERE id = %s
-        """,
-        (json.dumps(new_syns), chem_id),
-    )
-# ----------------------------------------------------------------
-def _upsert_chemical(cur, chem: CPAChemical) -> str:
-    """
-    Insert or update the chemical; return its UUID (text).
-    inchikey is preferred unique key; fallback = preferred_name.
-    """
-    if chem.inchikey:
+    seen: set[str] = set()
+
+    # Step 1: Enqueue names with preference flags
+    names_with_preference: list[tuple[str, bool]] = []
+    names_with_preference.append((preferred, True))
+    for synonym in syns:
+        names_with_preference.append((synonym, False))
+
+    # Step 2: Process names, skipping canonical duplicates
+    for name, is_preferred in names_with_preference:
+        canonical_name = _canon(name)
+        if canonical_name in seen:
+            continue
+        seen.add(canonical_name)
+
+        vec = get_embedding(canonical_name)
         cur.execute(
             """
-            INSERT INTO cpa_chemicals (inchikey, preferred_name, synonyms, embedding)
+            INSERT INTO cpa_chemical_aliases
+              (chemical_id, alias, embedding, is_preferred)
             VALUES (%s, %s, %s, %s)
-            ON CONFLICT (inchikey)
-            DO UPDATE SET preferred_name = EXCLUDED.preferred_name,
-            synonyms = EXCLUDED.synonyms,
-            embedding = EXCLUDED.embedding
-            RETURNING id;
+            ON CONFLICT DO NOTHING;
             """,
-            (chem.inchikey, chem.preferred_name, json.dumps(chem.synonyms), get_embedding(chem.preferred_name.lower())),
+            (chem_id, name, vec, is_preferred),
         )
-        chem_id = cur.fetchone()["id"]
-        _merge_synonyms(cur, chem_id, chem.synonyms)
-        return chem_id
 
-    # 2. Semantic path – no inchikey available
-    query_vec = get_embedding(chem.preferred_name.lower())
-    # nearest neighbour + its distance
+def _upsert_chemical(cur, chem: CPAChemical, paper_id: str | None = None) -> str:
+    """Safe upsert: semantic → attach valid, unique InChIKey → fallback."""
+    canon_name = _canon(chem.preferred_name)
+    q_vec      = get_embedding(canon_name)
+
+    # ── 1.  semantic match in alias table  ──────────────────────────
     cur.execute(
         """
-        SELECT id,
-            embedding <-> %s::vector AS distance
-        FROM   cpa_chemicals
-        WHERE  embedding IS NOT NULL
-        ORDER  BY distance
+        SELECT chemical_id, alias, embedding <-> %s::vector AS dist
+        FROM   cpa_chemical_aliases
+        ORDER  BY dist
         LIMIT  1;
         """,
-        (query_vec,),
+        (q_vec,),
     )
     row = cur.fetchone()
-    if row and row["distance"] is not None:
-        print(f'[TRACE] distance: {row["distance"]} for {chem}')
-        if row["distance"] < SIMILARITY_THRESHOLD:
-            chem_id = row["id"]
-            _merge_synonyms(cur, chem_id, [chem.preferred_name, *chem.synonyms])
-            return chem_id
-    # 3. Truly new – insert
-    print(f'[TRACE] Inserting new chemical: {chem}')
+    if row and row["dist"] < SIMILARITY_THRESHOLD:
+        chem_id = row["chemical_id"]
+
+        _upsert_aliases(cur, chem_id, chem.preferred_name, chem.synonyms)
+        return chem_id
+
+    # ── 2.  No semantic hit → try InChIKey upsert if key looks OK ───
+    if _is_valid_inchikey(chem.inchikey):
+        cur.execute(
+            """
+            INSERT INTO cpa_chemicals (inchikey, preferred_name, embedding)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (inchikey) DO UPDATE
+              SET preferred_name = EXCLUDED.preferred_name,
+                  embedding      = EXCLUDED.embedding
+            RETURNING id;
+            """,
+            (chem.inchikey, chem.preferred_name, q_vec),
+        )
+        chem_id = cur.fetchone()["id"]
+        _upsert_aliases(cur, chem_id, chem.preferred_name, chem.synonyms)
+        return chem_id
+
+    # ── 3.  Last resort: new row without inchikey + log suspect key ─
+    print(f"[TRACE] Inserting chemical: '{chem.preferred_name}' (no InChIKey) distance: {row['dist']} compared with: '{row['alias']}')")
     cur.execute(
         """
-        INSERT INTO cpa_chemicals (preferred_name, synonyms, embedding)
-        VALUES (%s, %s, %s)
+        INSERT INTO cpa_chemicals (preferred_name, embedding)
+        VALUES (%s, %s)
+        ON CONFLICT (preferred_name) DO UPDATE
+          SET embedding = EXCLUDED.embedding
         RETURNING id;
         """,
-        (
-            chem.preferred_name,
-            json.dumps(chem.synonyms),
-            query_vec,
-        ),
+        (chem.preferred_name, q_vec),
     )
-    return cur.fetchone()["id"]
+    chem_id = cur.fetchone()["id"]
+    _upsert_aliases(cur, chem_id, chem.preferred_name, chem.synonyms)
 
-
+    # Store the hallucinated or malformed key for later inspection
+    if chem.inchikey:
+        cur.execute(
+            "INSERT INTO cpa_unverified_inchikeys "
+            "(supplied_key, source_paper, note) VALUES (%s, %s, %s)",
+            (
+                chem.inchikey,
+                paper_id,
+                "Failed validation or duplicate; not stored in chemicals table.",
+            ),
+        )
+    return chem_id
 def _get_property_id(cur, chemical_id: str, ptype: PropertyType) -> str:
-    print(f'[TRACE] _get_property_id: {chemical_id}, {ptype}')
+    """
+    Ensure (chemical_id, prop_type) exists in `chemical_properties`
+    and return its UUID.
+
+    • INSERT if missing.
+    • Otherwise fetch the existing row.
+    """
     cur.execute(
         """
         INSERT INTO chemical_properties (chemical_id, prop_type)
@@ -108,24 +143,25 @@ def _get_property_id(cur, chemical_id: str, ptype: PropertyType) -> str:
         (chemical_id, ptype.value),
     )
     row = cur.fetchone()
-    if row:                                # we inserted
+    if row:                      # inserted just now
         return row["id"]
-    # already existed
+
+    # already existed → fetch
     cur.execute(
         "SELECT id FROM chemical_properties WHERE chemical_id = %s AND prop_type = %s",
         (chemical_id, ptype.value),
     )
     return cur.fetchone()["id"]
 
-
 def _get_property_value_id(
     cur, prop_id: str, cpv: ChemicalPropertyValue
 ) -> str:
-    cur.execute(
-        """
-        INSERT INTO chemical_property_values
-          (property_id, value_kind, numeric_value, range_min, range_max,
-           raw_value, extra, unit)
+    try:
+        cur.execute(
+            """
+            INSERT INTO chemical_property_values
+              (property_id, value_kind, numeric_value, range_min, range_max,
+               raw_value, extra, unit)
         VALUES
           (%(property_id)s,%(value_kind)s,%(numeric_value)s,%(range_min)s,
            %(range_max)s,%(raw_value)s,%(extra)s,%(unit)s)
@@ -141,19 +177,21 @@ def _get_property_value_id(
             "extra": json.dumps(cpv.extra) if cpv.extra is not None else None,
             "unit": cpv.unit,
         },
-    )
-    row = cur.fetchone()
-    if row:            # inserted
-        return row["id"]
-    # already exists — retrieve id
-    cur.execute(
-        """
-        SELECT id FROM chemical_property_values
-        WHERE property_id = %s
-        """,
-        (prop_id,),
-    )
-    return cur.fetchone()["id"]
+        )   
+        row = cur.fetchone()
+        if row:
+            return row["id"]
+        cur.execute(
+            """
+            SELECT id FROM chemical_property_values
+            WHERE property_id = %s
+            """,
+            (prop_id,),
+        )
+        return cur.fetchone()["id"]
+    except Exception as e:
+        print(f"[WARN] Failed to insert property value: {e}")
+        return None
 
 
 def store_cpa_data(md5_hash: str) -> None:
@@ -165,7 +203,7 @@ def store_cpa_data(md5_hash: str) -> None:
     with connection_ctx() as conn, conn.cursor(row_factory=dict_row) as cur:
         # 1. pull JSON
         cur.execute(
-            "SELECT cpa_facts_json FROM papers WHERE md5_hash = %s", (md5_hash,)
+            "SELECT cpa_facts_json, doi FROM papers WHERE md5_hash = %s", (md5_hash,)
         )
         row = cur.fetchone()
         if not row or not row["cpa_facts_json"]:
@@ -174,8 +212,6 @@ def store_cpa_data(md5_hash: str) -> None:
         paper_json: Dict[str, Any] = row["cpa_facts_json"]
         paper = CPAPaperData.model_validate(paper_json)
         now = datetime.now()
-
-        print(f'[TRACE] AGENT PROPERTIES: {paper.agent_properties}')
         # 2. loop over agent properties
         for ap in paper.agent_properties:
             # 2.1 ensure chemical row exists
@@ -184,7 +220,7 @@ def store_cpa_data(md5_hash: str) -> None:
                 preferred_name=ap.agent_label,
                 synonyms=[],
             )
-            chemical_id = _upsert_chemical(cur, chem)
+            chemical_id = _upsert_chemical(cur, chem, row["doi"])
 
             # 2.2 ensure (chemical, prop_type) row exists
             prop_id = _get_property_id(cur, chemical_id, ap.prop_type)
@@ -198,6 +234,10 @@ def store_cpa_data(md5_hash: str) -> None:
             )
             prop_val_id = _get_property_value_id(cur, prop_id, cpv)
 
+            if row['doi']:
+                paper_id = row['doi']
+            else:
+                paper_id = paper.paper_id
             # 2.4 always add reference (duplicates are negligible)
             cur.execute(
                 """
@@ -208,9 +248,9 @@ def store_cpa_data(md5_hash: str) -> None:
                 """,
                 (
                     prop_val_id,
-                    paper.paper_id,
+                    paper_id,
                     ap.quote,
-                    str(paper.link) if paper.link is not None else None,
+                    str(paper_id) if paper_id is not None else None,
                 ),
             )
 

--- a/source/pipelines/post_processing/experiment_ingest.py
+++ b/source/pipelines/post_processing/experiment_ingest.py
@@ -1,0 +1,44 @@
+# pipelines/post_processing/experiment_ingest.py
+from __future__ import annotations
+from typing import List, Dict, Any
+from distiller.postgres_connection import cursor_ctx
+from psycopg.types.json import Json
+
+def _paper_uuid_from_md5(cur, md5_hash: str) -> str | None:
+    cur.execute("SELECT id FROM papers WHERE md5_hash = %s;", (md5_hash,))
+    row = cur.fetchone()
+    return row["id"] if row else None
+
+
+def insert_experiments(paper_md5: str, experiments: List[Dict[str, Any]]) -> None:
+    if not experiments:
+        return
+
+    with cursor_ctx(commit=True) as cur:
+        paper_uuid = _paper_uuid_from_md5(cur, paper_md5)
+        if paper_uuid is None:
+            raise RuntimeError(f"No `papers` row for md5={paper_md5}")
+
+        rows = [
+            (
+                paper_uuid,
+                e.get("id"),
+                e.get("performed_in_this_paper", True),
+                e.get("label"),
+                e.get("method"),
+                Json(e["biological_context"]) if e.get("biological_context") else None,
+                e["quote"],
+            )
+            for e in experiments
+        ]
+
+        cur.executemany(
+            """
+            INSERT INTO experiments
+                (paper_id, local_id, performed_in_this_paper, label, method,
+                biological_context, quote)
+            VALUES (%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT DO NOTHING;
+            """,
+            rows,
+        )

--- a/source/pipelines/post_processing/formulation_ingest.py
+++ b/source/pipelines/post_processing/formulation_ingest.py
@@ -1,0 +1,249 @@
+# pipelines/post_processing/formulation_ingest.py
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Dict, Any, Tuple
+from uuid import UUID
+from pipelines.utils.pipeline_utils import resolve_alias_id
+
+from distiller.postgres_connection import cursor_ctx
+from psycopg.types.json import Json
+from pipelines.utils.embeddings import (
+    get_embedding,
+    SIMILARITY_THRESHOLD,
+)
+def insert_placeholder_chemical(
+    cur,
+    *,
+    label: str,
+    role: str = "CARRIER",   # CPA | ADJUVANT | CARRIER
+) -> tuple[UUID, UUID]:
+    """
+    Ensure a stub chemical & its preferred alias exist, then return
+    (alias_id, chemical_id).
+
+    • If the alias already exists globally, re-use it (and its chemical).
+    • Otherwise: create a new chemical (inchikey = NULL, role = <role>)
+      and make <label> its preferred alias.
+    """
+    canon = label.strip().lower()
+    emb   = get_embedding(canon)
+
+    # 0️⃣  Does the alias already exist globally?
+    cur.execute(
+        "SELECT id, chemical_id FROM cpa_chemical_aliases WHERE alias = %s;",
+        (label,),
+    )
+    row = cur.fetchone()
+    if row:
+        return row["id"], row["chemical_id"]
+
+    # 1️⃣  Create a stub chemical
+    cur.execute(
+        """
+        INSERT INTO cpa_chemicals
+              (inchikey, preferred_name, role, embedding)
+        VALUES (NULL, %s, %s::cryoprotectant_roles, %s)
+        RETURNING id;
+        """,
+        (label, role, emb),
+    )
+    chemical_id: UUID = cur.fetchone()["id"]
+
+    # 2️⃣  Insert preferred alias (guaranteed unique now)
+    cur.execute(
+        """
+        INSERT INTO cpa_chemical_aliases
+              (chemical_id, alias, embedding, is_preferred)
+        VALUES (%s, %s, %s, TRUE)
+        RETURNING id;
+        """,
+        (chemical_id, label, emb),
+    )
+    alias_id: UUID = cur.fetchone()["id"]
+
+    return alias_id, chemical_id
+
+# ───────────────────────── generic helpers ─────────────────────────
+
+def _paper_uuid_from_md5(cur, md5_hash: str) -> str | None:
+    cur.execute("SELECT id FROM papers WHERE md5_hash = %s;", (md5_hash,))
+    r = cur.fetchone()
+    return r["id"] if r else None
+
+def _experiment_uuid_from_map_or_db(
+    cur, paper_uuid: str, local_id: str, experiments: dict[str, str] | None
+) -> str | None:
+
+    cur.execute(
+        "SELECT id FROM experiments "
+        "WHERE paper_id = %s AND local_id = %s;",
+        (paper_uuid, local_id),
+    )
+    row = cur.fetchone()
+    return row["id"] if row else None
+
+def _amount_as_columns(
+    amt: dict | float | int | None,
+) -> Tuple[float | None, float | None, float | None, str | None]:
+    if amt is None:
+        return None, None, None, None
+    if isinstance(amt, (int, float)):
+        return float(amt), None, None, "POINT"
+
+    vtype = amt.get("value_type")
+    if vtype == "point":
+        return amt["value"], None, None, "POINT"
+    if vtype == "range":
+        return None, amt["min"], amt["max"], "RANGE"
+
+    return None, None, None, "STRUCT"
+
+# ─────────────────────────── ingest API ────────────────────────────
+
+def insert_formulations(
+    paper_md5: str,
+    formulations: List[Dict[str, Any]],
+    experiments: dict[str, str] | None = None,
+) -> None:
+    if not formulations:
+        return
+
+    with cursor_ctx(commit=True) as cur:
+        paper_uuid = _paper_uuid_from_md5(cur, paper_md5)
+        if paper_uuid is None:
+            raise RuntimeError(f"No `papers` row for md5={paper_md5}")
+
+        for f in formulations:
+            experiment_id = _experiment_uuid_from_map_or_db(
+                cur, paper_uuid, f["experiment_id"], experiments
+            )
+            if experiment_id is None:
+                print(
+                    f"[WARN] formulation skipped – "
+                    f"experiment {f['experiment_id']} not found for paper {paper_md5}"
+                )
+                continue
+
+            # 1️⃣  formulation header
+            cur.execute(
+                """
+                INSERT INTO formulations (experiment_id, label, quote)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (experiment_id, label) DO UPDATE
+                      SET quote = EXCLUDED.quote
+                RETURNING id;
+                """,
+                (experiment_id, f["label"], f["quote"]),
+            )
+            formulation_id = cur.fetchone()["id"]
+
+            # 2️⃣  components
+            comp_rows: list[Tuple] = []
+            prop_to_create: list[Tuple] = []   # (comp_dict, aux_tuple)
+
+            for comp in f["components"]:
+                # alias / chemical resolution for CPA + ADJUVANT
+                alias_id, chem_id = (None, None)
+                if comp["role"] in ("CPA", "ADJUVANT"):
+                    alias_id, chem_id = resolve_alias_id(
+                        cur,
+                        inchikey = comp.get("agent_id"),
+                        label    = comp["label"],
+                    )
+                if chem_id is None:
+                    alias_id, chem_id = insert_placeholder_chemical(
+                        cur,
+                        label = comp["label"],
+                        role  = comp["role"],
+                    )
+
+                num_val, rng_min, rng_max, vkind = _amount_as_columns(comp.get("amount"))
+
+                comp_rows.append(
+                    (
+                        formulation_id,
+                        comp["role"],
+                        chem_id,   # may be NULL
+                        alias_id,  # may be NULL
+                        num_val,
+                        comp.get("unit"),
+                        comp["quote"],
+                        comp.get("note"),
+                    )
+                )
+
+                if vkind in ("RANGE", "STRUCT"):
+                    prop_to_create.append((comp, (rng_min, rng_max, vkind, alias_id)))
+
+            if comp_rows:
+                cur.executemany(
+                    """
+                    INSERT INTO formulation_components
+                           (formulation_id, role, chemical_id, alias_id,
+                            amount, unit, quote, note)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+                    ON CONFLICT DO NOTHING;
+                    """,
+                    comp_rows,
+                )
+
+            # map alias_id → component_id
+            cur.execute(
+                """
+                SELECT id, alias_id
+                  FROM formulation_components
+                 WHERE formulation_id = %s;
+                """,
+                (formulation_id,),
+            )
+            alias_to_compid = {r["alias_id"]: r["id"] for r in cur.fetchall()}
+
+            # 3️⃣  dependent props for RANGE / STRUCT
+            for comp_dict, (rmin, rmax, vkind, alias_id) in prop_to_create:
+                comp_id = alias_to_compid.get(alias_id)
+                if comp_id is None:
+                    continue   # defensive; should not happen
+
+                # 3.a header
+                cur.execute(
+                    """
+                    INSERT INTO formulation_properties
+                           (experiment_id, component_id, prop_type)
+                    VALUES (%s, %s, 'LOADING_TEMPERATURE')
+                    ON CONFLICT (experiment_id, prop_type,
+                                 formulation_id, component_id)
+                    DO NOTHING
+                    RETURNING id;
+                    """,
+                    (experiment_id, comp_id),
+                )
+                prop_id = cur.fetchone()["id"]
+
+                # 3.b value row
+                cur.execute(
+                    """
+                    INSERT INTO formulation_property_values
+                           (property_id, value_kind,
+                            range_min, range_max, extra, unit)
+                    VALUES (%s,%s,%s,%s,%s,%s);
+                    """,
+                    (
+                        prop_id,
+                        vkind,
+                        rmin,
+                        rmax,
+                        Json(comp_dict["amount"]) if vkind == "STRUCT" else None,
+                        comp_dict.get("unit"),
+                    ),
+                )
+
+# NOTE: make sure you ran the schema patch:
+#   ALTER TABLE formulation_components
+#     ADD COLUMN IF NOT EXISTS alias_id uuid,
+#     ADD CONSTRAINT fk_formcomp_alias
+#         FOREIGN KEY (alias_id)
+#         REFERENCES cpa_chemical_aliases(id) ON DELETE RESTRICT;
+#   CREATE INDEX IF NOT EXISTS idx_formcomp_alias
+#       ON formulation_components(alias_id);

--- a/source/pipelines/utils/embeddings.py
+++ b/source/pipelines/utils/embeddings.py
@@ -12,3 +12,5 @@ def get_embedding(text: str) -> List[float]:
         model="text-embedding-3-large"
     )
     return rsp.data[0].embedding
+
+SIMILARITY_THRESHOLD = 0.38

--- a/source/pipelines/utils/embeddings.py
+++ b/source/pipelines/utils/embeddings.py
@@ -7,12 +7,8 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 
 @functools.lru_cache(maxsize=4096)
 def get_embedding(text: str) -> List[float]:
-    """
-    Returns a 1536‑dim OpenAI embedding for the given text.
-    Cached for the lifetime of the process.
-    """
     rsp = openai.embeddings.create(
         input=text,
-        model="text-embedding-3-small"  # 1536 dims, inexpensive
+        model="text-embedding-3-large"
     )
     return rsp.data[0].embedding

--- a/source/pipelines/utils/molecule_pass.py
+++ b/source/pipelines/utils/molecule_pass.py
@@ -1,0 +1,11 @@
+from .helpers import _llm_extract
+from distiller.schemas.agent import CPACoreData
+from jinja2 import Environment, FileSystemLoader
+
+_jinja = Environment(loader=FileSystemLoader("prompts"))
+
+def extract_agents(paper_text: str) -> list[dict] | None:
+    prompt = _jinja.get_template("agent_prompt.j2").render(
+        PAPER_TEXT=paper_text, SCHEMA=CPACoreData.model_json_schema()
+    )
+    return _llm_extract(prompt, CPACoreData)

--- a/source/pipelines/utils/pipeline_utils.py
+++ b/source/pipelines/utils/pipeline_utils.py
@@ -1,0 +1,102 @@
+import re
+from typing import List
+from uuid import UUID
+from pipelines.utils.embeddings import get_embedding
+from distiller.schemas.papers import PaperStatus
+import logging
+from distiller.postgres_connection import cursor_ctx
+SIMILARITY_THRESHOLD = 0.38
+
+# ────────────────────────── alias helpers ──────────────────────────
+
+_INCHI_PAT  = re.compile(r"^[A-Z]{14}-[A-Z]{10}-[A-Z]$", re.I)
+_EMBED_SQL  = """
+SELECT id, chemical_id, alias, embedding <-> %s::vector AS dist
+FROM   cpa_chemical_aliases
+ORDER  BY dist
+LIMIT  1;
+"""
+
+def _is_inchikey(k: str | None) -> bool:
+    return bool(k and _INCHI_PAT.match(k))
+
+def _canon(txt: str) -> str:
+    return txt.strip().lower()
+
+def _ensure_alias(
+    cur, *, chemical_id: UUID, label: str, emb: List[float]
+) -> UUID:
+    """Insert the label as a new alias (or refresh the embedding)."""
+    cur.execute(
+        """
+        INSERT INTO cpa_chemical_aliases (chemical_id, alias, embedding)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (chemical_id, alias) DO UPDATE
+              SET embedding = EXCLUDED.embedding
+        RETURNING id;
+        """,
+        (chemical_id, label, emb),
+    )
+    return cur.fetchone()["id"]
+
+def resolve_alias_id(
+    cur, *, inchikey: str | None, label: str
+) -> tuple[UUID | None, UUID | None]:
+    """
+    Return **(alias_id, chemical_id)** for a component.
+
+    1.  Exact InChIKey → cpa_chemicals, create alias if “label” missing.
+    2.  Otherwise: semantic match on `cpa_chemical_aliases` (pgvector).
+    """
+    # 1️⃣  direct InChIKey
+    if _is_inchikey(inchikey):
+        cur.execute("SELECT id FROM cpa_chemicals WHERE inchikey = %s;", (inchikey,))
+        row = cur.fetchone()
+        if row:
+            chem_id = row["id"]
+
+            cur.execute(
+                "SELECT id FROM cpa_chemical_aliases "
+                "WHERE chemical_id = %s AND alias = %s;",
+                (chem_id, label),
+            )
+            alias_row = cur.fetchone()
+            if alias_row:
+                return alias_row["id"], chem_id   # alias already present
+
+            # create missing alias
+            emb = get_embedding(_canon(label))
+            alias_id = _ensure_alias(cur, chemical_id=chem_id, label=label, emb=emb)
+            return alias_id, chem_id
+
+    # 2️⃣  embedding search
+    vec = get_embedding(_canon(label))
+    cur.execute(_EMBED_SQL, (vec,))
+    row = cur.fetchone()
+    if row and row["dist"] < SIMILARITY_THRESHOLD:
+        return row["id"], row["chemical_id"]
+
+    return None, None   # not found
+
+def stage_and_merge(stage_table: str, rows: list[dict], merge_fn: str):
+    if not rows:
+        return []
+    with cursor_ctx(commit=True) as cur:
+        # 1. COPY rows into the staging table (as JSONB)
+        tmp_json = [json.dumps(r) for r in rows]
+        cur.copy_from(io.StringIO("\n".join(tmp_json)),
+                      stage_table, columns=("data_json",))
+
+        # 2. Call the merge function; it returns (json_id, live_table_id)
+        cur.execute(f"SELECT * FROM {merge_fn}();")
+        return cur.fetchall()
+
+def update_workflow_status(paper_md5_hash: str, status: PaperStatus):
+    try:
+        with cursor_ctx(commit=True) as cur:
+            cur.execute(
+                "UPDATE papers SET status = %s WHERE md5_hash = %s;",
+                (status, paper_md5_hash),
+            )
+    except Exception as err:
+        logging.error(f"Failed to update workflow status for {paper_md5_hash}: {err}")

--- a/source/prompts/agent_prompt.j2
+++ b/source/prompts/agent_prompt.j2
@@ -1,0 +1,68 @@
+You are **CryoExtractor-Agents**, an information-extraction specialist for cryobiology papers.
+
+Your task: **return ONE JSON object with a single key `agents`.**  
+`agents` must be an array where every element is a valid **CPACoreData**.
+
+Example (for structure only — do not copy values):
+
+```json
+{
+  "agents": [
+    {
+      "inchikey": "WSNAFJHALSXBSN-UHFFFAOYSA-N",
+      "preferred_name": "Glycerol",
+      "synonyms": ["glycerin", "1,2,3-propanetriol"],
+      "role": "CPA"
+    },
+    {
+      "inchikey": "CZNQUACQKIXDN-UHFFFAOYSA-N",
+      "preferred_name": "Sucrose",
+      "synonyms": ["table sugar", "β-D-fructofuranosyl-α-D-glucopyranoside"],
+      "role": "ADJUVANT"
+    },
+    {
+      "inchikey": null,
+      "preferred_name": "Phosphate-Buffered Saline",
+      "synonyms": ["PBS", "phosphate buffer"],
+      "role": "CARRIER"
+    }
+  ]
+}
+Extraction rules
+	1.	Output ONLY JSON – no markdown, code fences, or comments.
+	2.	Every core_id must be a new RFC-4122 UUID v4.
+	3.	preferred_name (common human label) is required.
+synonyms is an array of alternative names/abbreviations.
+	4.	inchikey: provide if the paper gives it; otherwise null.
+	5.	role assignment
+	•	CPA      = classical intracellular cryoprotectants (DMSO, EG, glycerol…)
+	•	ADJUVANT = additives that enhance CPA action or reduce toxicity
+(sugars, amino acids, FBS, antioxidants)
+	•	CARRIER  = bulk medium / buffer (MEM, PBS, saline, Ringer, etc.)
+	6.	Do not hallucinate chemicals; include only those clearly mentioned
+in a cryopreservation context.
+	7.	Omit any optional field you cannot verify; do not invent values.
+
+Workflow (follow strictly)
+	1.	Scan the entire paper (title → conclusions) for every distinct
+chemical entity used in cryopreservation experiments or formulations.
+	2.	For each entity: gather preferred_name, synonyms, inchikey
+(if present), and classify role.
+	3.	Build a CPACoreData object, attach a fresh core_id, and append
+it to agents.
+	4.	When done, wrap the array in an object – exactly:
+{ "agents": [ … ] }
+	5.	Self-check the output against the JSON schema below; fix any errors
+before returning.
+
+⸻
+
+JSON SCHEMA
+
+{{SCHEMA}}
+
+⸻
+
+PAPER (Markdown, truncated if necessary)
+
+{{PAPER_TEXT}}

--- a/source/prompts/agent_property_prompt.j2
+++ b/source/prompts/agent_property_prompt.j2
@@ -1,0 +1,89 @@
+You are **CryoExtractor-PhysChem**.  
+From the cryobiology paper below, extract every *intrinsic* (formulation-independent) physicochemical property that is explicitly stated for any CPA or ADJUVANT.
+
+Return **ONE JSON object with one key: `properties`**.
+
+```json
+{ "properties": [ … AgentProperty … ] }
+```
+
+Hard rules
+	1.	Output ONLY JSON – no markdown, code-fences, or comments.
+	2.	agent_label required; agent_id (InChIKey) optional.
+	3.	Numeric wrappers
+	•	point → {"value_type":"point","value":12.3}
+	•	range → {"value_type":"range","min":10,"max":15,"inclusive":[true,true]}
+	4.	quote must be a verbatim substring from the paper that supports the value.
+	6.	If you cannot verify a field, omit it – do NOT hallucinate.
+
+⸻
+
+What counts as "intrinsic"?
+
+PROP TYPE POSSIBLE VALUES:
+```
+    MOLECULAR_MASS                 = "MOLECULAR_MASS"
+    SOLUBILITY                     = "SOLUBILITY"
+    VISCOSITY                      = "VISCOSITY"
+    TG_PRIME                       = "TG_PRIME"
+    PARTITION_COEFFICIENT          = "PARTITION_COEFFICIENT"
+    DIELECTRIC_CONSTANT            = "DIELECTRIC_CONSTANT"
+    THERMAL_CONDUCTIVITY           = "THERMAL_CONDUCTIVITY"
+    HEAT_CAPACITY                  = "HEAT_CAPACITY"
+    THERMAL_EXPANSION_COEFFICIENT  = "THERMAL_EXPANSION_COEFFICIENT"
+    CRYSTALLIZATION_TEMPERATURE    = "CRYSTALLIZATION_TEMPERATURE"
+    DIFFUSION_COEFFICIENT          = "DIFFUSION_COEFFICIENT"
+    HYDROGEN_BOND_DONORS_ACCEPTORS = "HYDROGEN_BOND_DONORS_ACCEPTORS"
+    SOURCE_OF_COMPOUND             = "SOURCE_OF_COMPOUND"
+    GRAS_CERTIFICATION             = "GRAS_CERTIFICATION"
+    MELTING_POINT                  = "MELTING_POINT"
+    HYDROPHOBICITY                 = "HYDROPHOBICITY"
+    DENSITY                        = "DENSITY"
+    REFRACTIVE_INDEX               = "REFRACTIVE_INDEX"
+    SURFACE_TENSION                = "SURFACE_TENSION"
+    PH                             = "PH"
+    OSMOLALITY_OSMOLARITY          = "OSMOLALITY_OSMOLARITY"
+    POLAR_SURFACE_AREA             = "POLAR_SURFACE_AREA"
+```
+
+# Example (do not replicate, for reference only)
+```json
+{
+  "properties": [
+    {
+      "agent_id": "WSNAFJHALSXBSN-UHFFFAOYSA-N",
+      "agent_label": "Glycerol",
+      "prop_type": "MOLECULAR_MASS",
+      "value": { "value_type": "point", "value": 92.09 },
+      "unit": "g/mol",
+      "quote": "The molecular weight of glycerol is 92.09 g mol⁻¹."
+    },
+    {
+      "agent_id": "IAZDPXIOMUYVGZ-UHFFFAOYSA-N",
+      "agent_label": "Dimethyl sulfoxide",
+      "prop_type": "VISCOSITY",
+      "value": {
+        "value_type": "range",
+        "min": 1.90,
+        "max": 2.05,
+        "inclusive": [true, true]
+      },
+      "unit": "mPa.s",
+      "quote": "The viscosity of DMSO at 25 °C ranged from 1.90 to 2.05 mPa·s."
+    }
+  ]
+}
+```
+– Your real output may contain more or fewer items; values and units must match the paper exactly.
+
+⸻
+
+JSON SCHEMA
+
+{{SCHEMA}}
+
+⸻
+
+PAPER (Markdown – truncated if needed)
+
+{{PAPER_TEXT}}

--- a/source/prompts/experiment_extraction/v4_experiment_prompt.j2
+++ b/source/prompts/experiment_extraction/v4_experiment_prompt.j2
@@ -1,0 +1,63 @@
+Scientific Experiment Extractor
+Extract all experiments performed by the authors and return a JSON array conforming to the provided schema.
+Instructions
+
+Extract only experiments performed by the authors - skip cited/referenced work
+Use exact terminology from the source text
+Include dimensions only when specific measurements are provided
+Set fields to null if not mentioned - don't invent data
+Return only valid JSON - no markdown formatting
+Source chunks must total minimum 1000 words - use multiple list elements for different paper sections
+
+Dimension Types (include only if measurements given)
+
+MASS: organ/tissue mass (g, mg)
+VOLUME: cell/organoid volume (nL, pL, µm3)
+DIAMETER: cell diameter (µm)
+SIZE: tissue dimensions - width/height/thickness (mm, µm)
+
+Source Chunk Requirements
+
+List of exact text excerpts from the paper covering the experiment
+Each element = one continuous text section from the paper
+Total word count across all elements ≥ 1000 words
+Include all sections containing numeric values related to the experiment
+
+Example
+Input: "Primary rat hepatocytes were isolated from healthy adult Sprague-Dawley rats. Liver tissue sections (2mm × 2mm × 1mm) weighing approximately 8 mg were prepared for analysis. Cells measured 18-22 μm in diameter and were cultured in specialized medium. We performed MTT viability assays and Western blotting to assess protein expression."
+Output:
+json[
+  {
+    "performed_in_this_paper": true,
+    "label": "Hepatocyte isolation and tissue preparation",
+    "method": "tissue sectioning",
+    "biological_context": {
+      "species": "rat",
+      "organ": "liver",
+      "tissue": "liver tissue sections", 
+      "cell_line": "primary hepatocytes",
+      "developmental_stage": "adult",
+      "health_status": "healthy",
+      "dimensions": {
+        "kind": "SIZE",
+        "width": 2.0,
+        "height": 2.0, 
+        "thickness": 1.0,
+        "unit": "mm",
+        "quote": "Liver tissue sections (2mm × 2mm × 1mm)"
+      }
+    },
+    "quote": "Primary rat hepatocytes were isolated from healthy adult Sprague-Dawley rats. Liver tissue sections (2mm × 2mm × 1mm) weighing approximately 8 mg were prepared for analysis.",
+    "source_chunk": [
+      "Primary rat hepatocytes were isolated from healthy adult Sprague-Dawley rats using standard perfusion techniques. The isolation protocol involved perfusion with calcium-free buffer followed by collagenase digestion for 15-20 minutes at 37°C. Liver tissue sections (2mm × 2mm × 1mm) weighing approximately 8 mg were prepared for analysis using precision cutting techniques.",
+      "Cell viability was assessed immediately after isolation using trypan blue exclusion, with only preparations showing >85% viability being used for subsequent experiments. Cells measured 18-22 μm in diameter and were cultured in specialized medium containing Williams' E medium supplemented with 10% fetal bovine serum, 100 nM insulin, 100 nM dexamethasone, and antibiotic-antimycotic solution.",
+      "Culture conditions were maintained at 37°C in a humidified atmosphere with 5% CO2. We performed MTT viability assays and Western blotting to assess protein expression. Statistical analysis was performed using ANOVA with post-hoc testing."
+    ]
+  }
+]
+Schema:
+```json
+{{ SCHEMA }}
+```
+Text to analyze:
+{{ PAPER_TEXT }}

--- a/source/prompts/formulation_extraction/v5_formulation_prompt.j2
+++ b/source/prompts/formulation_extraction/v5_formulation_prompt.j2
@@ -1,0 +1,116 @@
+{# -------------------------------------------------------------------
+   Formulation extractor – v3
+   Variables injected by Python:
+     PAPER_TEXT     – source passage (markdown)
+     EXPERIMENT_ID  – deterministic experiment key (e.g. EXPT-17)
+     SCHEMA         – FormulationPass JSON Schema
+   ------------------------------------------------------------------- #}
+
+Extract cryobiology formulation data from PAPER_TEXT. Return only JSON conforming to FormulationPass schema.
+
+CRITICAL RULES:
+1. Extract only information explicitly stated in PAPER_TEXT
+2. Never hallucinate or infer missing data
+3. Each formulation must have unique content
+4. Return only valid JSON
+
+EXTRACTION PROTOCOL:
+
+Extract every formulation described in the passage.
+
+MANDATORY FIELDS for each formulation:
+- experiment_id: Always "{{ EXPERIMENT_ID }}"
+- label: Short descriptive name from paper
+- components: Array with at least 1 component. If 0 components, skip entire formulation
+- quote: Must contain all numeric values for all components in this formulation
+
+COMPONENT EXTRACTION RULES:
+- Extract each component separately. Never combine with "and" or "with"
+- Example: "DMSO (10%) and glycerol (5%)" yields 2 separate components
+- DO NOT INCLUDE QUANTITIES ON THE NAME OF THE COMPONENT."3 M Dymethyl sulfoxide" is  Dymethyl sulfoxide. "1.5 M Ethylene Glycol and 1.5 M Dimethylsulfoxide" is Ethylene Glycol and Dimethyl Sulfoxide. Quantities are stored in a different property.
+
+
+Required component fields:
+- role: Exactly one of "CPA", "ADJUVANT", "CARRIER"
+- agent_id: If role is CPA or ADJUVANT, use valid InChIKey or null. If role is CARRIER, always null
+- amount: Mandatory. Structure: {"value_type": "point", "value": 8} or {"value_type": "range", "min": 5, "max": 15}
+- unit: Mandatory unit string
+- quote: Exact text containing this component's quantity/unit. Connect fragments with "..."
+
+FORMULATION QUOTE:
+Must capture all component quantities. Connect disparate fragments with "..."
+
+OPTIONAL FIELDS:
+Include dependent_properties only if passage reports explicit numerical measurement.
+Omit any field not mentioned in text.
+
+
+EXAMPLE OUTPUT:
+```json
+{
+  "formulations": [
+    {
+      "formulation_id": "b3d4e5f6-7890-1234-5678-9abcdef01234",
+      "label": "VS55 vitrification solution",
+      "experiment_id": "EXPT-17",
+      "components": [
+        {
+          "component_id": "c1d2e3f4-5678-9012-3456-7890abcdef12",
+          "role": "CPA",
+          "label": "Dimethyl sulfoxide",
+          "agent_id": "IAZDPXIOMUYVGZ-UHFFFAOYSA-N",
+          "amount": {"value_type": "point", "value": 3.1},
+          "unit": "M",
+          "quote": "The VS55 solution contained 3.1 M dimethyl sulfoxide"
+        },
+        {
+          "component_id": "d2e3f4g5-6789-0123-4567-890abcdef123",
+          "role": "CPA",
+          "label": "Formamide",
+          "agent_id": "ZHNUHDYFZUAESO-UHFFFAOYSA-N",
+          "amount": {"value_type": "point", "value": 3.1},
+          "unit": "M",
+          "quote": "3.1 M formamide was included as a permeating cryoprotectant"
+        },
+        {
+          "component_id": "e3f4g5h6-7890-1234-5678-90abcdef1234",
+          "role": "CPA",
+          "label": "Propylene glycol",
+          "agent_id": "DNIAPMSPPWPWGF-UHFFFAOYSA-N",
+          "amount": {"value_type": "point", "value": 2.2},
+          "unit": "M",
+          "quote": "Additionally, 2.2 M propylene glycol was added"
+        },
+        {
+          "component_id": "f4g5h6i7-8901-2345-6789-0abcdef12345",
+          "role": "CARRIER",
+          "label": "Euro-Collins solution",
+          "agent_id": null,
+          "amount": {"value_type": "point", "value": 100},
+          "unit": "%",
+          "quote": "All components were dissolved in Euro-Collins solution as the carrier medium"
+        }
+      ],
+      "dependent_properties": [
+        {
+          "property_type": "viability",
+          "value": 85.3,
+          "unit": "%",
+          "conditions": "post-thaw assessment at 24 hours"
+        }
+      ],
+      "quote": "The VS55 solution contained 3.1 M dimethyl sulfoxide (Me2SO, Sigma-Aldrich) and 3.1 M formamide (Sigma-Aldrich) as permeating cryoprotectants. Additionally, 2.2 M propylene glycol was added to enhance glass-forming properties ... All components were dissolved in Euro-Collins solution as the carrier medium. The final solution had a pH of 7.8 and osmolality of 3,200 mOsm/kg ... Post-thaw viability assessment at 24 hours showed 85.3% cell survival compared to fresh controls ... The solution was cooled at a rate of 1°C/min to -80°C before plunging into liquid nitrogen"
+    }
+  ]
+}
+```
+
+
+OUTPUT:
+Return only the JSON object.
+
+SCHEMA:
+{{ SCHEMA }}
+
+PAPER_TEXT:
+{{ PAPER_TEXT }}

--- a/source/prompts/molecule_extraction/agent_property_prompt.j2
+++ b/source/prompts/molecule_extraction/agent_property_prompt.j2
@@ -1,0 +1,101 @@
+You are **CryoExtractor-PhysChem**.  
+From the cryobiology paper below, extract every *intrinsic* (formulation-independent) physicochemical property that is explicitly stated for any CPA or ADJUVANT.
+
+Return **ONE JSON object with one key: `properties`**.
+
+```json
+{ "properties": [ … AgentProperty … ] }
+```
+
+Hard rules
+	1.	Output ONLY JSON – no markdown, code-fences, or comments.
+	2.	agent_label required; agent_id (InChIKey) optional.
+	3.	Numeric wrappers
+	•	point → {"value_type":"point","value":12.3}
+	•	range → {"value_type":"range","min":10,"max":15,"inclusive":[true,true]}
+	4.	quote must be a verbatim substring from the paper that supports the value.
+	6.	If you cannot verify a field, omit it – do NOT hallucinate.
+
+Extract ONLY the actual measured values, NOT measurement methods or conditions.
+
+✅ CORRECT - Extract the number:
+- "The viscosity of DMSO at 25°C was 2.0 mPa·s" → value: {"value_type":"point","value":2.0}
+- "Viscosity ranged from 1.9 to 2.1 mPa·s" → value: {"value_type":"range","min":1.9,"max":2.1}
+
+❌ INCORRECT - Don't extract method descriptions:
+- "measured in the temperature range of 20 to 45 °C with falling ball viscometry" ← This is a METHOD, not a VALUE
+- "determined by differential scanning calorimetry" ← This is a METHOD
+- "assessed using standard protocols" ← This is a METHOD
+
+If a paper mentions a property but doesn't give the actual numeric value, omit that property entirely.
+⸻
+
+What counts as "intrinsic"?
+
+PROP TYPE POSSIBLE VALUES:
+```
+    MOLECULAR_MASS                 = "MOLECULAR_MASS"
+    SOLUBILITY                     = "SOLUBILITY"
+    VISCOSITY                      = "VISCOSITY"
+    TG_PRIME                       = "TG_PRIME"
+    PARTITION_COEFFICIENT          = "PARTITION_COEFFICIENT"
+    DIELECTRIC_CONSTANT            = "DIELECTRIC_CONSTANT"
+    THERMAL_CONDUCTIVITY           = "THERMAL_CONDUCTIVITY"
+    HEAT_CAPACITY                  = "HEAT_CAPACITY"
+    THERMAL_EXPANSION_COEFFICIENT  = "THERMAL_EXPANSION_COEFFICIENT"
+    CRYSTALLIZATION_TEMPERATURE    = "CRYSTALLIZATION_TEMPERATURE"
+    DIFFUSION_COEFFICIENT          = "DIFFUSION_COEFFICIENT"
+    HYDROGEN_BOND_DONORS_ACCEPTORS = "HYDROGEN_BOND_DONORS_ACCEPTORS"
+    SOURCE_OF_COMPOUND             = "SOURCE_OF_COMPOUND"
+    GRAS_CERTIFICATION             = "GRAS_CERTIFICATION"
+    MELTING_POINT                  = "MELTING_POINT"
+    HYDROPHOBICITY                 = "HYDROPHOBICITY"
+    DENSITY                        = "DENSITY"
+    REFRACTIVE_INDEX               = "REFRACTIVE_INDEX"
+    SURFACE_TENSION                = "SURFACE_TENSION"
+    PH                             = "PH"
+    OSMOLALITY_OSMOLARITY          = "OSMOLALITY_OSMOLARITY"
+    POLAR_SURFACE_AREA             = "POLAR_SURFACE_AREA"
+```
+
+# Example (do not replicate, for reference only)
+```json
+{
+  "properties": [
+    {
+      "agent_id": "WSNAFJHALSXBSN-UHFFFAOYSA-N",
+      "agent_label": "Glycerol",
+      "prop_type": "MOLECULAR_MASS",
+      "value": { "value_type": "point", "value": 92.09 },
+      "unit": "g/mol",
+      "quote": "The molecular weight of glycerol is 92.09 g mol⁻¹."
+    },
+    {
+      "agent_id": "IAZDPXIOMUYVGZ-UHFFFAOYSA-N",
+      "agent_label": "Dimethyl sulfoxide",
+      "prop_type": "VISCOSITY",
+      "value": {
+        "value_type": "range",
+        "min": 1.90,
+        "max": 2.05,
+        "inclusive": [true, true]
+      },
+      "unit": "mPa.s",
+      "quote": "The viscosity of DMSO at 25 °C ranged from 1.90 to 2.05 mPa·s."
+    }
+  ]
+}
+```
+– Your real output may contain more or fewer items; values and units must match the paper exactly.
+
+⸻
+
+JSON SCHEMA
+
+{{SCHEMA}}
+
+⸻
+
+PAPER (Markdown – truncated if needed)
+
+{{PAPER_TEXT}}

--- a/source/prompts/molecule_extraction/v2_agent_property_prompt.j2
+++ b/source/prompts/molecule_extraction/v2_agent_property_prompt.j2
@@ -8,14 +8,41 @@ Return **ONE JSON object with one key: `properties`**.
 ```
 
 Hard rules
+    0. Values must be numeric measurements, not experimental methods or conditions.
 	1.	Output ONLY JSON – no markdown, code-fences, or comments.
 	2.	agent_label required; agent_id (InChIKey) optional.
 	3.	Numeric wrappers
 	•	point → {"value_type":"point","value":12.3}
 	•	range → {"value_type":"range","min":10,"max":15,"inclusive":[true,true]}
-	4.	quote must be a verbatim substring from the paper that supports the value.
+	4.	quote must be a verbatim substring from the paper that CONTAINS THE NUMERIC VALUE. The quote must include the measurement OTHERWISE DO NOT RETURN IT.
 	6.	If you cannot verify a field, omit it – do NOT hallucinate.
 
+Extract ONLY the actual measured values, NOT measurement methods or conditions.
+
+✅ CORRECT - Extract the number:
+- "The viscosity of DMSO at 25°C was 2.0 mPa·s" → value: {"value_type":"point","value":2.0}
+- "Viscosity ranged from 1.9 to 2.1 mPa·s" → value: {"value_type":"range","min":1.9,"max":2.1}
+
+❌ INCORRECT - Don't extract method descriptions:
+- "measured in the temperature range of 20 to 45 °C with falling ball viscometry" ← This is a METHOD, not a VALUE
+- "determined by differential scanning calorimetry" ← This is a METHOD
+- "assessed using standard protocols" ← This is a METHOD
+
+If a paper mentions a property but doesn't give the actual numeric value, omit that property entirely.
+
+QUOTE REQUIREMENTS:
+
+The quote must contain the actual numeric value being extracted, not just the chemical name.
+
+✅ CORRECT quotes (contain the number):
+- "The molecular weight of glycerol is 92.09 g mol⁻¹"
+- "DMSO has a viscosity of 2.0 mPa·s at 25°C"
+- "The density of ethylene glycol was measured as 1.11 g/cm³"
+
+❌ INCORRECT quotes (missing the number):
+- "Me2SO" ← NO! This doesn't contain the 78 g/mol value
+- "Dimethyl sulfoxide" ← NO! Where's the measurement?
+- "DMSO was used as cryoprotectant" ← NO! No property value mentioned
 ⸻
 
 What counts as "intrinsic"?


### PR DESCRIPTION
# Objective
The objective of this pull request is to implement a refactoring to the previous workflow pipeline, dividing all functional blocks into re-usable modules that can be re-used by different parsers and LLM models. This will allow for further development of the pipeline, adding new parsers and LLM models, without having to modify the existing code much. Therefore, this will serve as the foundation of the playground framework we should develop to iterate over the prompts and the data extraction process.

# How to test

`poetry install --no-root`

`poetry lock`in case of an error with poetry.lock file

`poetry shell`

`python source/extractor.py examples`

# Changelog 2026-07-31
- support for claude-4-sonnet added
- cross reference between experiments, formulations and chemical molecules implemented. A view has also been created to easily query the data for further visualization (`database/tables_backup/views.sql`)
- formulations and experiments tables implemented (`database/tables_backup/formulations_experiments.sql`)
- integration of two workflow pipelines (GPT-4.1-mini and Claude-sonnet-4-20250514) for structured data extraction and transformation (`source/pipelines/pipeline_orchestration.py`).
- refactoring of workflow pipeline to make it more modular and easier to maintain (source/pipelines/pipeline_orchestration.py).
- jinja templates implemented for prompt generation and prompt variable substitution (`source/distiller/prompts/`).
- rework on modularizing extraction functions. Now each extraction function is responsible for a single task and returns a single object. They were relocated to `source/distiller/utils/llm_extraction.py`.
- folder restructuring to better separate the different components of the pipeline:
  - `source/pipelines/post_processing/agent_property_ingest.py` contains the main workflow for `agent property ingestion`.
  - `source/pipelines/post_processing/experiment_ingest.py` contains the main workflow for `experiment ingestion`.
  - `source/pipelines/post_processing/formulation_ingest.py` contains the main workflow for `formulation ingestion`.

# Poetry packages added
- anthropic
- jinja2
- backoff